### PR TITLE
05chore: ignore build artifacts and normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+﻿* text=auto
+*.py text eol=lf
+*.f text eol=lf
+*.f90 text eol=lf
+*.c text eol=lf
+*.h text eol=lf
+*.sh text eol=lf
+*.rst text eol=lf
+*.md text eol=lf
+*.so binary
+*.egg binary
+*.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
+﻿# Build output
 build/
-.idea/
+dist/
+*.egg-info/
+
+# Compiled extensions
+*.so
+*.pyd
+*.dll
+
+# f2py generated sources (do not commit)
+shakermaker/core/coremodule.c
+shakermaker/core/core-f2pywrappers.f
+
+# Python cache
 __pycache__/
+*.pyc
+*.pyo
+
+# IDE
+.idea/
+.vscode/


### PR DESCRIPTION
Ignore f2py generated sources and compiled extensions (*.so/*.pyd, coremodule.c, core-f2pywrappers.f, build/, *.egg-info) and add .gitattributes enforcing LF on sources and marking binaries. No code change.