### PR TITLE
11feat(stf): generalize SRF2 parameters and scale by slip

### DIFF
--- a/shakermaker/stf_extensions/srf2.py
+++ b/shakermaker/stf_extensions/srf2.py
@@ -3,33 +3,48 @@ from shakermaker.sourcetimefunction import SourceTimeFunction
 
 class SRF2(SourceTimeFunction):
     """
-    The SRF2 Source Time Function
+    SRF2 slip-rate source time function.
 
-    Implements the provided srf2 functional form as a slip rate function.
-    
-    Parameters:
-        Tp : float
-            The parameter Tp from the srf2 function.
-        Tr : float
-            The parameter Tr from the srf2 function.
-        dt : float
-            Time step for the source time function.
+    Builds a slip-rate (slip-velocity) function on ``[0, Tr)`` from three
+    phases: a rising sine branch for ``t < Tp``, a ``sqrt(a + b/t**2)``
+    plateau for ``Tp <= t < Te``, and a decaying sine tail for ``t >= Te``.
+    The function is normalised to unit area and then scaled by ``slip``.
+
+    :param Tr: Total rise time / duration of the function (s); ``t`` spans ``[0, Tr)``.
+    :type Tr: float
+    :param Tp: Peak time of the initial rising branch (s).
+    :type Tp: float
+    :param Te: Time at which the decaying tail begins (s).
+    :type Te: float
+    :param dt: Time step of the generated function (s).
+    :type dt: float
+    :param slip: Final slip used to scale the unit-area slip-rate.
+    :type slip: float
+    :param a: Constant term of the ``sqrt(a + b/t**2)`` envelope.
+    :type a: float
+    :param b: ``1/t**2`` coefficient of the ``sqrt(a + b/t**2)`` envelope.
+    :type b: float
     """
-    def __init__(self, Tp, Tr, dt):
+    def __init__(self, Tr, Tp, Te, dt, slip , a, b):
         SourceTimeFunction.__init__(self)
-        self._Tp = Tp
         self._Tr = Tr
+        self._Tp = Tp
+        self._Te = Te
         self._dt = dt
+        self._slip = slip
+        self._a = a
+        self._b = b
+
     
     def _generate_data(self):
         t, svf = self._srf2_function()
         self._t = t
-        self._data = svf
+        self._svf = svf
+        self._data = svf * self._slip
 
     def _srf2_function(self):
-        Te = 0.7 * self._Tr
-        a = 1.
-        b = 100.
+        a = self._a
+        b = self._b
 
         t = np.arange(0, self._Tr, self._dt)
         Nt = len(t)
@@ -37,9 +52,9 @@ class SRF2(SourceTimeFunction):
 
         i1 = t < self._Tp
         svf[i1] = t[i1] / self._Tp * np.sqrt(a + b / self._Tp**2) * np.sin(np.pi * t[i1] / (2 * self._Tp))
-        i2 = np.logical_and(self._Tp <= t, t < Te)
+        i2 = np.logical_and(self._Tp <= t, t < self._Te)
         svf[i2] = np.sqrt(a + b / t[i2]**2)
-        i3 = t >= Te
+        i3 = t >= self._Te
         svf[i3] = np.sqrt(a + b / t[i3]**2) * np.sin(5/3 * np.pi * (self._Tr - t[i3]) / self._Tr)
 
         A = np.trapz(svf, dx=self._dt)


### PR DESCRIPTION
Expose Te, a, b as constructor args (previously hard-coded) and scale by slip. Usage SRF2(Tr=, Tp=, Te=, dt=, slip=, a=, b=). BREAKING only for positional callers.