### PR TITLE
34feat(ffsp): persist products for every realization

### DIFF
--- a/shakermaker/ffsp/Makefile_f2py
+++ b/shakermaker/ffsp/Makefile_f2py
@@ -1,0 +1,75 @@
+# Makefile to build FFSP with f2py
+#
+# Usage:
+#   make           - Build the ffsp_core module
+#   make clean     - Remove build artefacts
+#   make test      - Test the built module
+
+F90     = gfortran
+F77     = gfortran
+F2PY    = f2py
+
+# Compilation flags
+F90FLAGS = -O3 -fPIC
+F77FLAGS = -O3 -std=legacy -fPIC
+
+# Source files
+FORTRAN_SOURCES = ffsp_wrapper.f90 \
+                  ffsp_comm.f90 \
+                  spfield_n.f90 \
+                  dcf_subs_1.f90 \
+                  slip_rate.f90 \
+                  ffsp_tool.f
+
+# Python module name
+MODULE_NAME = ffsp_core
+
+# Output file
+SO_FILE = $(MODULE_NAME).cpython-*.so
+
+.PHONY: all clean test help
+
+all: $(MODULE_NAME)
+
+# Build the module with f2py
+$(MODULE_NAME): $(FORTRAN_SOURCES) ffsp.pyf
+	@echo "=================================================="
+	@echo "Building the FFSP module with f2py..."
+	@echo "=================================================="
+	$(F2PY) -c ffsp.pyf $(FORTRAN_SOURCES) \
+		--f90flags="$(F90FLAGS)" \
+		--f77flags="$(F77FLAGS)" \
+		-m $(MODULE_NAME)
+	@echo ""
+	@echo "Build succeeded"
+	@echo "Module written: $(SO_FILE)"
+	@echo ""
+
+# Remove build artefacts
+clean:
+	@echo "Removing build artefacts..."
+	rm -f *.so *.o *.mod *.pyc __pycache__/*
+	rm -rf build/
+	@echo "Clean complete"
+
+# Basic module test
+test:
+	@echo "=================================================="
+	@echo "Testing the FFSP module..."
+	@echo "=================================================="
+	python3 -c "import ffsp_core; print('Module imported successfully'); print(dir(ffsp_core))"
+
+# Help
+help:
+	@echo "Makefile to build FFSP with f2py"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  make           - Build the ffsp_core module"
+	@echo "  make clean     - Remove build artefacts"
+	@echo "  make test      - Test the built module"
+	@echo "  make help      - Show this help"
+	@echo ""
+	@echo "Required files:"
+	@echo "  - ffsp_wrapper.f90 (main wrapper)"
+	@echo "  - ffsp.pyf (f2py interface)"
+	@echo "  - ffsp_comm.f90, spfield_n.f90, etc. (original FFSP code)"

--- a/shakermaker/ffsp/__init__.py
+++ b/shakermaker/ffsp/__init__.py
@@ -1,0 +1,11 @@
+# FFSP (Finite Fault Stochastic Process) compiled Fortran extension.
+# The public API is exposed through FFSPSource in shakermaker.ffspsource.
+# This module exposes only the low-level compiled wrapper when available.
+
+try:
+    from shakermaker.ffsp.ffsp_core import ffsp_run_wrapper
+    _ffsp_available = True
+except ImportError:
+    _ffsp_available = False
+
+__all__ = ["ffsp_run_wrapper"] if _ffsp_available else []

--- a/shakermaker/ffsp/dcf_subs_1.f90
+++ b/shakermaker/ffsp/dcf_subs_1.f90
@@ -1,0 +1,246 @@
+!
+!================================================================
+!
+subroutine dcf_logmean(fc1,fc2,logmean)
+ use time_freq
+ implicit none
+ integer::  i,j,i1,i2
+ real,parameter :: pi=3.14159265,pi2=2.0*pi,pi4=pi2*pi2
+ real:: fc1,fc2,energy
+ real:: moment_rate(nphf),sum
+ real:: logmean(lnpt)
+ if(io_dva.ne.1.and.io_dva.ne.2.and.io_dva.ne.3)then
+    write(*,*)"io_dva has only three options 1 2 3 "
+    write(*,*)"io_dva= ",io_dva
+    stop
+ endif
+ if(nbb.lt.1.or.nee.gt.(lnpt-1))then
+    write(*,*)"nb and ne exceed the possible range"
+    write(*,*)"nb ne = ",nbb,nee
+    stop
+ endif
+ do i=1,nphf
+   freq(i)=(i-1+1.0e-5)*df
+   moment_rate(i)=1.0/((1.+(freq(i)/fc1)**4.0)**0.25)/((1.+(freq(i)/fc2)**4.0)**0.25)
+   if(io_dva.eq.2)then
+      moment_rate(i)=pi2*freq(i)*moment_rate(i)
+   elseif(io_dva.eq.3)then
+      moment_rate(i)=pi4*freq(i)*freq(i)*moment_rate(i)
+   endif
+ enddo
+ do i=nbb,nee
+    i1=2**(i-1)
+    i2=2**i-1
+    sum=0.0
+    do j=i1,i2
+       sum=sum+log(moment_rate(j))
+    enddo
+    logmean(i)=sum/(i2-i1+1)
+ enddo
+end subroutine dcf_logmean
+!
+!================================================================
+! td is the shortest duration for percent*m0
+subroutine stf_duration(percent,td,tb,te)
+ use time_freq
+ implicit none
+ integer:: i,j,ntd,n0,n1,n2,ib,ie,n
+ integer:: i_t0,i_t1,i_t2
+ real:: percent,td,tb,te,left
+ real:: total,target,epslon,x
+ real:: svf(ntime),m0(ntime)
+ svf=0.0
+ m0=0.0
+ total=0.0
+ call sum_point_svf(svf)
+ total=sum(svf)
+ epslon=(1-1.0e-6)*total
+ target=total*percent
+ left=total-target
+ n0=1
+ n1=1
+ n2=1
+ i_t0=0
+ i_t1=0
+ i_t2=0
+ do i=2,ntime
+   m0(i)=m0(i-1)+svf(i)
+   if(m0(i).ge.left.and.i_t0.eq.0)then
+     n0=i
+     i_t0=1
+   endif
+   if(m0(i).ge.target.and.i_t1.eq.0)then
+     n1=i
+     i_t1=1
+   endif
+   if(m0(i).ge.epslon.and.i_t2.eq.0)then
+     n2=i
+     i_t2=1
+   endif
+ end do
+ write(*,*)"n0 n1 n2",n0,n1,n2,dt,total
+ ntd=n1
+ ib=1
+ ie=n1
+ do i=1,n0
+   do j=n1,n2
+     n=j-i+1
+     x=m0(j)-m0(i)
+     if((n.lt.ntd).and.x.ge.target)then
+       ntd=n
+       ib=i
+       ie=j
+     endif
+   end do
+ end do
+ td=ntd*dt
+ tb=(ib-1)*dt
+ te=ie*dt
+ return
+end subroutine stf_duration
+!
+!
+!================================================================
+!
+subroutine stf_synth_logmean(rmt,logmean)
+ use time_freq
+ implicit none
+ integer:: i,j,i1,i2
+ real,parameter :: pi=3.14159265,pi2=2.0*pi,pi4=pi2*pi2
+ real:: rmt,dtmt,fc1,fc2,energy
+ real:: svf(ntime),moment_rate(nphf)
+ real:: density,vs,coef,tim,dtm,sum
+ real:: logmean(lnpt)
+ svf=0.0
+ call sum_point_svf(svf)
+ call realft(svf,ntime,-1)
+ dtmt=dt/rmt
+ write(*,*)"dtmt=",dtmt
+ do i=1,ntime
+    svf(i)=svf(i)*dtmt
+ enddo
+
+ do i=1,nphf-1
+    moment_rate(i)=sqrt(svf(2*(i-1)+1)**2+svf(2*(i-1)+2)**2)
+    freq(i)=(i-1+1.0e-5)*df
+    if(io_dva.eq.2)then ! velocity
+       moment_rate(i)=pi2*freq(i)*moment_rate(i)
+    elseif(io_dva.eq.3)then ! acceleration
+       moment_rate(i)=pi4*freq(i)*freq(i)*moment_rate(i)
+    endif
+ enddo
+ moment_rate(nphf)=svf(2)
+ do i=nbb,nee
+    i1=2**(i-1)
+    i2=2**i-1
+    sum=0.0
+    do j=i1,i2
+       sum=sum+log(moment_rate(j))
+    enddo
+
+    logmean(i)=sum/(i2-i1+1)
+ enddo
+end subroutine  stf_synth_logmean
+!
+!================================================================
+!
+subroutine misfit_ratio(rmt,fc1,fc2,misfit,misfit_2)
+  use time_freq
+  implicit none
+  integer:: i
+  real:: logmean_m(lnpt),logmean_s(lnpt)
+  real:: misfit,rmt,fc1,fc2,misfit_2
+  misfit=0.0
+  misfit_2=0.0
+  call stf_synth_logmean(rmt,logmean_s)
+  call dcf_logmean(fc1,fc2,logmean_m)
+  do i=nbb,nee
+!     write(*,*)i, logmean_s(i), logmean_m(i)
+     misfit=misfit+logmean_s(i)-logmean_m(i)
+     misfit_2=misfit_2+(logmean_s(i)-logmean_m(i))**2.0
+  enddo
+  misfit=exp(misfit/(nee-nbb+1.))
+  misfit_2=sqrt(misfit_2/(nee-nbb+1.))
+end subroutine misfit_ratio
+!
+!================================================================
+!
+subroutine misfit_lsq(rmt,fc1,fc2,misfit)
+  use time_freq
+  implicit none
+  integer:: i
+  real:: logmean_m(lnpt),logmean_s(lnpt)
+  real:: misfit,rmt,fc1,fc2
+  misfit=0.0
+  call stf_synth_logmean(rmt,logmean_s)
+  call dcf_logmean(fc1,fc2,logmean_m)
+  do i=nbb,nee
+!     write(*,*)i, logmean_s(i), logmean_m(i)
+     misfit=misfit+(logmean_s(i)-logmean_m(i))**2.0
+  enddo
+  misfit=sqrt(misfit/(nee-nbb+1.))
+end subroutine misfit_lsq
+!
+!================================================================
+!
+subroutine stf_synth_output(rmt,fc1,fc2)
+ use time_freq
+ implicit none
+ integer:: i,j,i1,i2
+ real:: rmt,fc1,fc2,energy
+ real:: svf(ntime),moment_rate(nphf),dcf(nphf)
+ real:: density,vs,coef,pi,tim,dtmt,sum
+ real:: logmean_m(lnpt),logmean_s(lnpt),f2(lnpt)
+!svf=0.0
+ call sum_point_svf(svf)
+ open(19,file='calsvf_tim.dat',status='replace')
+ write(19,*) ntime
+ do i=1,ntime
+    tim=(i-1)*dt
+    write(19,*) tim,svf(i)/rmt
+ enddo
+ close(19)
+
+ call realft(svf,ntime,-1)
+ dtmt=dt/rmt
+ do i=1,ntime
+    svf(i)=svf(i)*dtmt
+ enddo
+ do i=1,nphf-1
+    moment_rate(i)=sqrt(svf(2*(i-1)+1)**2+svf(2*(i-1)+2)**2)
+ enddo
+ moment_rate(nphf)=svf(nphf-1)
+ do i=1,lnpt-1
+    i1=2**(i-1)
+    i2=2**i-1
+    sum=0.0
+    do j=i1,i2
+       sum=sum+log(moment_rate(j))
+    enddo
+    logmean_s(i)=sum/(i2-i1+1)
+    f2(i)=0.5*(freq(i1)+freq(i2))
+ enddo
+
+ open(19,file='calsvf.dat')
+ write(19,*) nphf
+ do i=1,nphf
+    dcf(i)=1./((1.+(freq(i)/fc1)**4.0)**0.25)/((1.+(freq(i)/fc2)**4.0)**0.25)
+    write(19,*) freq(i),moment_rate(i),dcf(i)
+ enddo
+ close(19)
+ do i=1,lnpt-1
+    i1=2**(i-1)
+    i2=2**i-1
+    sum=0.0
+    do j=i1,i2
+       sum=sum+log(dcf(j))
+    enddo
+    logmean_m(i)=sum/(i2-i1+1)
+ enddo
+ open(19,file='logsvf.dat')
+ write(19,*)lnpt-1
+ do i=1,lnpt-1
+    write(19,*)f2(i),logmean_s(i),logmean_m(i)
+ enddo
+ close(19)
+end subroutine stf_synth_output

--- a/shakermaker/ffsp/dcf_subs_1.f90
+++ b/shakermaker/ffsp/dcf_subs_1.f90
@@ -183,23 +183,22 @@ end subroutine misfit_lsq
 !
 !================================================================
 !
-subroutine stf_synth_output(rmt,fc1,fc2)
+subroutine capture_spectral_realization(rmt,stf,moment_rate,logmean_s)
  use time_freq
  implicit none
  integer:: i,j,i1,i2
- real:: rmt,fc1,fc2,energy
- real:: svf(ntime),moment_rate(nphf),dcf(nphf)
- real:: density,vs,coef,pi,tim,dtmt,sum
- real:: logmean_m(lnpt),logmean_s(lnpt),f2(lnpt)
-!svf=0.0
+ real:: rmt,dtmt,sum
+ real,dimension(ntime),intent(OUT):: stf
+ real,dimension(nphf),intent(OUT):: moment_rate
+ real,dimension(lnpt-1),intent(OUT):: logmean_s
+! Keep the large work array on the heap to avoid the small Windows stack.
+ real,allocatable:: svf(:)
+ allocate(svf(ntime))
+ svf=0.0
  call sum_point_svf(svf)
- open(19,file='calsvf_tim.dat',status='replace')
- write(19,*) ntime
  do i=1,ntime
-    tim=(i-1)*dt
-    write(19,*) tim,svf(i)/rmt
+    stf(i)=svf(i)/rmt
  enddo
- close(19)
 
  call realft(svf,ntime,-1)
  dtmt=dt/rmt
@@ -218,29 +217,6 @@ subroutine stf_synth_output(rmt,fc1,fc2)
        sum=sum+log(moment_rate(j))
     enddo
     logmean_s(i)=sum/(i2-i1+1)
-    f2(i)=0.5*(freq(i1)+freq(i2))
  enddo
-
- open(19,file='calsvf.dat')
- write(19,*) nphf
- do i=1,nphf
-    dcf(i)=1./((1.+(freq(i)/fc1)**4.0)**0.25)/((1.+(freq(i)/fc2)**4.0)**0.25)
-    write(19,*) freq(i),moment_rate(i),dcf(i)
- enddo
- close(19)
- do i=1,lnpt-1
-    i1=2**(i-1)
-    i2=2**i-1
-    sum=0.0
-    do j=i1,i2
-       sum=sum+log(dcf(j))
-    enddo
-    logmean_m(i)=sum/(i2-i1+1)
- enddo
- open(19,file='logsvf.dat')
- write(19,*)lnpt-1
- do i=1,lnpt-1
-    write(19,*)f2(i),logmean_s(i),logmean_m(i)
- enddo
- close(19)
-end subroutine stf_synth_output
+ deallocate(svf)
+end subroutine capture_spectral_realization

--- a/shakermaker/ffsp/ffsp.pyf
+++ b/shakermaker/ffsp/ffsp.pyf
@@ -1,0 +1,120 @@
+!    -*- f90 -*-
+! Note: the context of this file is case sensitive.
+
+python module ffsp_core
+    interface
+        subroutine ffsp_run_wrapper( &
+            id_sf_type_in, freq_min_in, freq_max_in, &
+            fault_length_in, fault_width_in, &
+            x_hypc_in, y_hypc_in, depth_hypc_in, &
+            xref_hypc_in, yref_hypc_in, &
+            magnitude_in, fc_main_1_in, fc_main_2_in, rv_avg_in, &
+            ratio_rise_in, &
+            strike_in, dip_in, rake_in, &
+            pdip_max_in, prake_max_in, &
+            nsubx_in, nsuby_in, &
+            nb_taper_trbl_in, &
+            seeds_in, &
+            id_ran1_in, id_ran2_in, &
+            angle_north_to_x_in, &
+            is_moment_in, &
+            nlayers_in, &
+            vp_in, vs_in, rho_in, thick_in, qa_in, qb_in, &
+            n_realizations_out, npts_out, &
+            x_out, y_out, z_out, &
+            slip_out, rupture_time_out, rise_time_out, peak_time_out, &
+            strike_out, dip_out, rake_out, &
+            ave_tr_out, ave_tp_out, ave_vr_out, err_spectra_out, pdf_out, &
+            ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
+            stf_time_out, stf_out, &
+            freq_spec_out, moment_rate_out, dcf_out, &
+            freq_center_out, logmean_synth_out, logmean_dcf_out &
+        )
+
+            ! Input: Fault parameters
+            integer intent(in) :: id_sf_type_in
+            real intent(in) :: freq_min_in
+            real intent(in) :: freq_max_in
+            real intent(in) :: fault_length_in
+            real intent(in) :: fault_width_in
+            real intent(in) :: x_hypc_in
+            real intent(in) :: y_hypc_in
+            real intent(in) :: depth_hypc_in
+            real intent(in) :: xref_hypc_in
+            real intent(in) :: yref_hypc_in
+            real intent(in) :: magnitude_in
+            real intent(in) :: fc_main_1_in
+            real intent(in) :: fc_main_2_in
+            real intent(in) :: rv_avg_in
+            real intent(in) :: ratio_rise_in
+            real intent(in) :: strike_in
+            real intent(in) :: dip_in
+            real intent(in) :: rake_in
+            real intent(in) :: pdip_max_in
+            real intent(in) :: prake_max_in
+            integer intent(in) :: nsubx_in
+            integer intent(in) :: nsuby_in
+            integer dimension(4),intent(in) :: nb_taper_trbl_in
+            integer dimension(3),intent(in) :: seeds_in
+            integer intent(in) :: id_ran1_in
+            integer intent(in) :: id_ran2_in
+            real intent(in) :: angle_north_to_x_in
+            integer intent(in) :: is_moment_in
+            
+            ! Input: Velocity model
+            integer intent(in) :: nlayers_in
+            real dimension(nlayers_in),intent(in),depend(nlayers_in) :: vp_in
+            real dimension(nlayers_in),intent(in),depend(nlayers_in) :: vs_in
+            real dimension(nlayers_in),intent(in),depend(nlayers_in) :: rho_in
+            real dimension(nlayers_in),intent(in),depend(nlayers_in) :: thick_in
+            real dimension(nlayers_in),intent(in),depend(nlayers_in) :: qa_in
+            real dimension(nlayers_in),intent(in),depend(nlayers_in) :: qb_in
+            
+            ! Output: Dimensions
+            integer intent(out) :: n_realizations_out
+            integer intent(out) :: npts_out
+            
+            ! Output: Source parameters (explicit dimensions based on inputs)
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: x_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: y_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: z_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: slip_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: rupture_time_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: rise_time_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: peak_time_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: strike_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: dip_out
+            real dimension(nsubx_in*nsuby_in,id_ran2_in-id_ran1_in+1),intent(out),depend(nsubx_in,nsuby_in,id_ran1_in,id_ran2_in) :: rake_out
+            
+            ! Output: Statistics
+            real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: ave_tr_out
+            real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: ave_tp_out
+            real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: ave_vr_out
+            real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: err_spectra_out
+            real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: pdf_out
+            
+            ! Output: Spectral data dimensions
+            integer intent(out) :: ntime_spec_out
+            integer intent(out) :: nphf_spec_out
+            integer intent(out) :: lnpt_spec_out
+            
+            ! Output: STF time domain (max size 131072, actual size in ntime_spec_out)
+            real dimension(131072),intent(out) :: stf_time_out
+            real dimension(131072),intent(out) :: stf_out
+            
+            ! Output: Spectrum frequency domain (max size 65536, actual size in nphf_spec_out)
+            real dimension(65536),intent(out) :: freq_spec_out
+            real dimension(65536),intent(out) :: moment_rate_out
+            real dimension(65536),intent(out) :: dcf_out
+            
+            ! Output: Octave-averaged spectrum (max size 17, actual size in lnpt_spec_out)
+            real dimension(17),intent(out) :: freq_center_out
+            real dimension(17),intent(out) :: logmean_synth_out
+            real dimension(17),intent(out) :: logmean_dcf_out
+
+        end subroutine ffsp_run_wrapper
+    end interface
+end python module ffsp_core
+
+! This file was auto-generated with f2py (version:2).
+! See http://cens.ioc.ee/projects/f2py2e/

--- a/shakermaker/ffsp/ffsp.pyf
+++ b/shakermaker/ffsp/ffsp.pyf
@@ -25,6 +25,7 @@ python module ffsp_core
             slip_out, rupture_time_out, rise_time_out, peak_time_out, &
             strike_out, dip_out, rake_out, &
             ave_tr_out, ave_tp_out, ave_vr_out, err_spectra_out, pdf_out, &
+            fc_main_1_out, fc_main_2_out, &
             ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
             stf_time_out, stf_out, &
             freq_spec_out, moment_rate_out, dcf_out, &
@@ -92,6 +93,8 @@ python module ffsp_core
             real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: ave_vr_out
             real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: err_spectra_out
             real dimension(id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: pdf_out
+            real intent(out) :: fc_main_1_out
+            real intent(out) :: fc_main_2_out
             
             ! Output: Spectral data dimensions
             integer intent(out) :: ntime_spec_out
@@ -100,16 +103,16 @@ python module ffsp_core
             
             ! Output: STF time domain (max size 131072, actual size in ntime_spec_out)
             real dimension(131072),intent(out) :: stf_time_out
-            real dimension(131072),intent(out) :: stf_out
+            real dimension(131072,id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: stf_out
             
             ! Output: Spectrum frequency domain (max size 65536, actual size in nphf_spec_out)
             real dimension(65536),intent(out) :: freq_spec_out
-            real dimension(65536),intent(out) :: moment_rate_out
+            real dimension(65536,id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: moment_rate_out
             real dimension(65536),intent(out) :: dcf_out
             
             ! Output: Octave-averaged spectrum (max size 17, actual size in lnpt_spec_out)
             real dimension(17),intent(out) :: freq_center_out
-            real dimension(17),intent(out) :: logmean_synth_out
+            real dimension(17,id_ran2_in-id_ran1_in+1),intent(out),depend(id_ran1_in,id_ran2_in) :: logmean_synth_out
             real dimension(17),intent(out) :: logmean_dcf_out
 
         end subroutine ffsp_run_wrapper

--- a/shakermaker/ffsp/ffsp_comm.f90
+++ b/shakermaker/ffsp/ffsp_comm.f90
@@ -1,0 +1,47 @@
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+MODULE sp_sub_f
+ implicit NONE
+ save
+ integer:: nsubx,nsuby,nsum,ncxp,ncyp,nseg,id_sf_type,layer
+ integer:: ir_Mw,ir_Dip,ir_Fl,ir_Fw
+!
+ integer:: id_cl=1
+ integer:: id_lrtp=1
+!
+ real:: rstm_mean,pktm_mean,td_target,t_percent
+ real:: Mw,Moment_o,fc_main_1,fc_main_2,flx,fwy,dx,dy,x_hypc,y_hypc,depth_hypc, &
+        lat_hypc,lon_hypc
+
+ real:: smoment,hfrd,sp1,sq1,slip_clx,slip_cly,slip_pw, &
+        vmin_ratio,vmax_ratio,vp1,vq1,rv_clx,rv_cly,rv_pw,&
+        rs_max,pk_max,rp1,rq1,rs_clx,rs_cly,rs_pw,cr_sl_rs,cr_sl_vc,&
+        cr_pk_vc,pk_pw
+ real, allocatable, dimension(:):: slip,rstm,rptm,rpvel,pktm,lrtp,&
+                                   rake_prt,dip_prt,amz_prt
+ real, allocatable, dimension(:):: beta,amu,taper,depth_source
+ real, allocatable, dimension(:):: vvp,vvs,roh,thk,qp,qs
+ real, allocatable, dimension(:):: lx_seg,str_seg,dip_seg,rak_seg, &
+                                   lon_seg,lat_seg,xfps,yfps,zfps
+ integer, allocatable, dimension(:):: nxx_seg
+END MODULE sp_sub_f
+!
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+MODULE fdtim_2d
+ implicit NONE
+ save
+ integer:: nx_2d,nz_2d
+ real cxp,cyp,grid_2d
+ real, allocatable, dimension(:):: rtx,rtz
+END MODULE fdtim_2d
+!
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+MODULE time_freq
+ implicit NONE
+ save
+ integer:: ntime,nphf,nfe1,nfe2
+! Add four new parameters for DCF, Chen Ji, 2020
+ integer:: lnpt,nbb,nee,io_dva
+!
+ real:: dt,df,cft1
+ real, allocatable, dimension(:):: freq
+END MODULE time_freq

--- a/shakermaker/ffsp/ffsp_dcf_v2.f90
+++ b/shakermaker/ffsp/ffsp_dcf_v2.f90
@@ -1,0 +1,321 @@
+Program ffsp_dcf_v3
+!
+! This code output the spatial distribution of source parameters
+!
+! The relationship between Moment magnitude and moment
+!           log10(Mo) = 1.5 Mw+16.1
+! The unit of Mo is dyn-cm (Kanamori 1977)
+! The unit of input parameters are km (length), km/s (Velocity),
+!       g/cm^3 (density), degree (Angle)
+!
+! This code call the subroutines or functions in source_param2.f
+!
+! Written by Pengcheng Liu
+! Copyright (c) 2005 by Pengcheng Liu
+!
+
+! adding the relationships found by Schmedes et al. (2010, 2013)
+! Chen Ji, 2020
+! A new function is defined to calculate the quality of source model.
+! The best model is selected as spfile_best
+!======================================================================
+ use sp_sub_f
+ implicit NONE
+!
+ character(len=72):: vsfile,spfile,spfile_best,spfile_plot
+ character(len=3):: charnum
+ integer, dimension(4):: nb_taper_TRBL
+ integer:: getlen,idum1,idum2,idum3,id_ran1,id_ran2,&
+           is_moment,nlch,nsource,i,j,k
+ real:: xref_hypc,yref_hypc,strike,dip,rake,angle_north_to_x, &
+        freq_min,freq_max,rv_avg,cft1
+ real:: sp2,drp,rdip,rstrike,cosx,sinx,str_ref,dip_ref,area_sub, &
+        summ,rmt,rvc,xij,yij,xs,ys,xps,yps,zps,factor,rakei,dipi,&
+        pamzi,pdip_max,prake_max
+ real::rise_time
+ real::ave_tr,ave_tp,ave_vr,err_spectra,pdf,pdf_min
+ integer::io_model_out,id_min
+ integer:: idum1_master, idum2_master, idum3_master
+
+ open(8,file='ffsp.inp',status='old')
+ open(7,file='ffsp.inf',status='unknown')
+!
+! Inputing the fault parameters
+!
+ write(7,*) 'Enter the index of slip rate function'
+ read(8,*)  id_sf_type, freq_min, freq_max
+ write(7,*) id_sf_type, freq_min, freq_max
+
+ write(7,*) ' Enter the length and width of main fault'
+ read(8,*)  flx,fwy
+ write(7,*) flx,fwy
+
+ write(7,*) ' Enter the distance in the strike and down dip'
+ write(7,*) ' direction, and the depth of the hypocenter'
+ read(8,*)  x_hypc, y_hypc, depth_hypc
+ write(7,*) x_hypc, y_hypc, depth_hypc
+
+ write(7,*) 'Enter the coordinates  of hypocenter'
+ read(8,*)  xref_hypc,yref_hypc
+ write(7,*) xref_hypc,yref_hypc
+
+ write(7,*) 'Enter the moment(N-m), corner frequency(Hz) and ', &
+            'Average rupture speed'
+
+ read(8,*)  Moment_o,fc_main_1,fc_main_2,rv_avg
+ write(7,*) Moment_o,fc_main_1,fc_main_2,rv_avg
+
+ write(7,*) 'Enter the ratio of time between slip-rate increase', &
+            ' and rise time'
+
+ read(8,*)  cft1
+ write(7,*) cft1
+
+ write(7,*) ' Enter the strike, dip and rake of main fault'
+ read(8,*)  strike,dip,rake
+ write(7,*) strike,dip,rake
+
+ write(7,*) 'Enter Max. perturbation on the dip and rake'
+ read(8,*)  pdip_max,prake_max
+ write(7,*) pdip_max,prake_max
+
+ write(7,*) ' Enter the subfaults number along strike adn dip'
+ read(8,*)  nsubx,nsuby
+ write(7,*) nsubx,nsuby
+
+ write(7,*) ' Enter the numbers of subfault to be tapered at each side'
+ !           Top-Right-Bottom-Left
+ read(8,*)  (nb_taper_TRBL(i), i=1,4)
+ write(7,*) (nb_taper_TRBL(i), i=1,4)
+
+ write(7,*) ' Enter the seed for generating random numbers'
+ read(8,*)  idum1,idum2,idum3
+ write(7,*) idum1,idum2,idum3
+
+ write(7,*)'Enter first and last index of random generations'
+ read(8,*)  id_ran1,id_ran2
+ write(7,*) id_ran1,id_ran2
+!
+!  Enter name of files with 1D velocity structure
+!
+ write(7,*) ' Enter the name of file with velocity', &
+            ' structure of source region'
+ read(8,'(1a)')  vsfile
+ write(7,'(1a)') vsfile
+!
+!  The Parameters for outputing results
+!
+ write(7,*) 'Enter the angle (degree) from North to X-Axis ', &
+            '(clockwise) of SYN. code'
+ read(8,*)  angle_north_to_x
+ write(7,*) angle_north_to_x
+
+ write(7,*) 'Do you output moment(1), slip-area (2), or slip(3) '
+ read(8,*)  is_moment
+ write(7,*) is_moment
+
+ write(7,*) ' Enter the file name of output source parameters'
+ read(8,'(1a)')  spfile
+ write(7,'(1a)') spfile
+ close(8)
+
+!
+ if(Moment_o < 12.0) Moment_o=10**(1.5*Moment_o+9.05)
+ Mw=(alog10(Moment_o)-9.05)/1.5
+
+ sp2=1.0
+
+ 
+ if(Mw < 5.3) then
+   fc_main_1 = 10**(1.474 - 0.415*Mw)
+ else
+   fc_main_1 = 10**(2.375 - 0.585*Mw)
+ endif
+
+ fc_main_2 = 10**(3.250 - 0.5*Mw)
+
+ write(*,*) 'The corner freqs are:',fc_main_1,fc_main_2
+ 
+!------------------------------------------------------------------
+! Inputting 1D velocity structure
+!  assigning values for vvp, vvs, roh, thk, qp qs
+ call xmodel(vsfile)
+!
+!  in spfield: set the initial parameters for generating the source parameters
+!  rv_avg: average rupture velocity
+ !  freq_max: using to assign nfe1, nfe2 (0.5 - 0.9 freq_max)
+ !  cft1: tp/tr
+ !  nb_taper_TRBL
+
+ call mainfault(dip,freq_min,freq_max,rv_avg,cft1,nb_taper_TRBL)
+!
+ nlch=getlen(spfile)+1
+ spfile(nlch:nlch)='.'
+ drp=4.*atan(1.0)/180.0
+ rstrike=strike*drp
+ rdip=dip*drp
+ cosx=cos(angle_north_to_x*drp)
+ sinx=sin(angle_north_to_x*drp)
+ str_ref=(ncxp-0.5)*dx
+ dip_ref=(ncyp-0.5)*dy
+!
+ open(31,file='source_model.score')
+ write(31,*)id_ran2-id_ran1+1
+ open(11,file='source_model.list')
+ write(11,118) 1, nsubx, nsuby, &
+               dx*1000., dy*1000., x_hypc*1000.0, y_hypc*1000.0
+ write(11,119) xref_hypc*1000., yref_hypc*1000., angle_north_to_x
+ area_sub=1.e-15
+ if(is_moment == 3) area_sub=area_sub/(dx*dy)
+!
+ write(31,129)rstm_mean+pktm_mean,pktm_mean
+ 129     format("Target: average Risetime= ",f8.3," average peaktime= ",f8.4)
+ 130    format(5e15.5)
+ pdf_min=1.0e20
+ id_min=id_ran1
+ io_model_out=0
+ spfile_best=spfile
+ spfile_best(nlch:nlch+3)='.bst'
+ write(11,'(1a)') spfile_best(1:nlch+3)
+ close(11)
+ ! Guardar seeds master
+ idum1_master = idum1
+ idum2_master = idum2
+ idum3_master = idum3
+! write(*,*) 'DEBUG fortran: seeds_read=', idum1, idum2, idum3
+! write(*,*) 'DEBUG fortran: idum_master=', idum1_master, idum2_master, idum3_master
+
+ do nsource=id_ran1,id_ran2
+    ! Derive seeds unique to this source model
+    idum1 = idum1_master + (nsource - 1) * 10000
+    idum2 = idum2_master + (nsource - 1) * 20000
+    idum3 = idum3_master + (nsource - 1) * 30000
+
+   call dig2ch(nsource,charnum)
+   spfile(nlch+1:nlch+3)=charnum
+   write(31,'(1a)') spfile(1:nlch+3)
+
+   call random_field(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr,err_spectra)
+   pdf=((log(ave_tr)-log(rstm_mean+pktm_mean))/0.1)**2.0
+   pdf=pdf+((log(ave_tp)-log(pktm_mean))/0.1)**2.0
+   pdf=pdf+err_spectra
+
+   write(31,130)ave_tr,ave_tp,ave_vr,err_spectra,pdf
+   if(pdf.lt.pdf_min)then
+     pdf_min=pdf
+     id_min=nsource
+     io_model_out=1
+   endif
+   open(12,file=spfile)
+   write(12,*) is_moment,nsum,id_sf_type,cft1
+   if(io_model_out.eq.1)then
+     open(22,file=spfile_best)
+     write(22,*) is_moment,nsum,id_sf_type,cft1
+   endif
+!
+   summ=0.0
+   rmt=0.0
+   rvc=0.0
+   do  i=1,nsubx
+   do  j=1,nsuby
+     k=(i-1)*nsuby+j
+     xij=(i-0.5)*dx-str_ref
+     yij=(j-0.5)*dy-dip_ref
+     xs=xij*cos(rstrike)-yij*sin(rstrike)*cos(rdip)
+     ys=xij*sin(rstrike)+yij*cos(rstrike)*cos(rdip)
+     xps=xref_hypc  + xs*cosx+ys*sinx
+     yps=yref_hypc  - xs*sinx+ys*cosx
+     zps=depth_hypc + yij*sin(rdip)
+     factor=1.0
+     if(is_moment.gt.1) factor=area_sub/amu(k)
+     slip(k)=slip(k)*factor
+     rakei=rake+rake_prt(k)*35.0
+
+     dipi=dip+dip_prt(k)*pdip_max
+     rakei=rake+rake_prt(k)*prake_max
+     pamzi=amz_prt(k)
+!     rise_time=rstm(k)+pktm(k)
+     write(12,109) xps*1000.,yps*1000.,zps*1000., &
+          slip(k),rptm(k),rstm(k),pktm(k),strike,dipi,rakei
+     if(io_model_out.eq.1)then
+        write(22,109) xps*1000.,yps*1000.,zps*1000., &
+          slip(k),rptm(k),rstm(k),pktm(k),strike,dipi,rakei
+     endif
+     summ=summ+rstm(k)
+     rmt=rmt+slip(k)
+     rvc=rvc+rpvel(k)
+   enddo
+   enddo
+   close(12)
+   close(14)
+   write(*,*) 'Moment =', rmt
+   write(*,*) 'Avg-rst=', summ/nsubx/nsuby
+   write(*,*) 'Avg-rpv=', rvc/nsubx/nsuby
+   if(io_model_out.eq.1)then
+     close(22)
+     io_model_out=0
+   endif
+ enddo
+!
+ 109     format(4e15.7,6e12.4)
+ 118     format(I3, 2I5, 4e15.7)
+ 119     format(3e15.7)
+ close(7)
+ close(31)
+
+end program ffsp_dcf_v3
+!
+!======================================================================
+!
+subroutine xmodel(vsfile)
+! Inputting 1D velocity structure from file vsfile
+!
+ use sp_sub_f
+ implicit NONE
+ character(len=72):: vsfile
+ integer:: j
+ real:: freq_ref
+
+ open(17,file=vsfile)
+! The number of layer
+ read(17,*) layer, freq_ref
+!
+ allocate(vvp(layer+2),vvs(layer+2),roh(layer+2), &
+          thk(layer+2),qp(layer+2),qs(layer+2))
+!
+! P-wave, S-wave velocity, density, thickness, Qp, and Qs of each layer
+ do j=1,layer
+   read(17,*) vvp(j),vvs(j),roh(j),thk(j),qp(j),qs(j)
+ enddo
+ close(17)
+
+end subroutine xmodel
+!
+!======================================================================
+!
+subroutine dig2ch(n,ch)
+ implicit none
+ integer:: n,n1,n2,n3,ntmp,nzero
+ character(len=3):: ch
+
+ n1=n/100
+ ntmp=n-n1*100
+ n2=ntmp/10
+ n3=ntmp-n2*10
+
+ nzero=ichar('0')
+ ch(1:1)=char(nzero+n1)
+ ch(2:2)=char(nzero+n2)
+ ch(3:3)=char(nzero+n3)
+
+end subroutine dig2ch
+!
+!=====================================================================
+!
+function getlen(string)
+ implicit NONE
+ character(len=*):: string
+ integer:: getlen
+ string=adjustl(string)
+ getlen=len_trim(string)
+end function getlen

--- a/shakermaker/ffsp/ffsp_tool.f
+++ b/shakermaker/ffsp/ffsp_tool.f
@@ -1,0 +1,2401 @@
+c
+c+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+      SUBROUTINE realft(data,n,isign)
+c
+c  Calculates the Fourier transform of a set of real data points.
+c  isign=-1, forward tranform of a real-valued data point.
+c     The real-valued first (zero frequency) last (fmax) components
+c     of the complex transform are returned as element data(1) and
+c     data(2), respectively. n must be a opwer of 2.
+c  isign=+1, inverse transform of a complex data array. The result
+c     in this case must be multipled by 2/n.
+c
+      IMPLICIT NONE
+      INTEGER isign,n
+      REAL data(n)
+CU    USES four1
+      INTEGER i,i1,i2,i3,i4,n2p3
+      REAL c1,c2,h1i,h1r,h2i,h2r,wis,wrs
+      DOUBLE PRECISION theta,wi,wpi,wpr,wr,wtemp
+      theta=3.141592653589793d0/dble(n/2)
+      c1=0.5
+      if (isign.eq.-1) then
+        c2=-0.5
+        theta=-theta
+        call four1(data,n/2,isign)
+      else
+        c2=0.5
+      endif
+      wpr=-2.0d0*sin(0.5d0*theta)**2
+      wpi=sin(theta)
+      wr=1.0d0+wpr
+      wi=wpi
+      n2p3=n+3
+      do 11 i=2,n/4
+        i1=2*i-1
+        i2=i1+1
+        i3=n2p3-i2
+        i4=i3+1
+        wrs=sngl(wr)
+        wis=sngl(wi)
+        h1r=c1*(data(i1)+data(i3))
+        h1i=c1*(data(i2)-data(i4))
+        h2r=-c2*(data(i2)+data(i4))
+        h2i=c2*(data(i1)-data(i3))
+        data(i1)=h1r+wrs*h2r-wis*h2i
+        data(i2)=h1i+wrs*h2i+wis*h2r
+        data(i3)=h1r-wrs*h2r+wis*h2i
+        data(i4)=-h1i+wrs*h2i+wis*h2r
+        wtemp=wr
+        wr=wr*wpr-wi*wpi+wr
+        wi=wi*wpr+wtemp*wpi+wi
+11    continue
+      data(n/2+2)=-data(n/2+2)
+      if (isign.eq.-1) then
+        h1r=data(1)
+        data(1)=h1r+data(2)
+        data(2)=h1r-data(2)
+      else
+        h1r=data(1)
+        data(1)=c1*(h1r+data(2))
+        data(2)=c1*(h1r-data(2))
+        call four1(data,n/2,isign)
+      endif
+      return
+      END
+C
+c+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+      SUBROUTINE four1(data,nn,isign)
+      IMPLICIT NONE
+      INTEGER isign,nn
+      REAL data(2*nn)
+      INTEGER i,istep,j,m,mmax,n
+      REAL tempi,tempr
+      DOUBLE PRECISION theta,wi,wpi,wpr,wr,wtemp
+      n=2*nn
+      j=1
+      do 11 i=1,n,2
+        if(j.gt.i)then
+          tempr=data(j)
+          tempi=data(j+1)
+          data(j)=data(i)
+          data(j+1)=data(i+1)
+          data(i)=tempr
+          data(i+1)=tempi
+        endif
+        m=n/2
+1       if ((m.ge.2).and.(j.gt.m)) then
+          j=j-m
+          m=m/2
+        goto 1
+        endif
+        j=j+m
+11    continue
+      mmax=2
+2     if (n.gt.mmax) then
+        istep=2*mmax
+        theta=6.28318530717959d0/(isign*mmax)
+        wpr=-2.d0*sin(0.5d0*theta)**2
+        wpi=sin(theta)
+        wr=1.d0
+        wi=0.d0
+        do 13 m=1,mmax,2
+          do 12 i=m,n,istep
+            j=i+mmax
+            tempr=sngl(wr)*data(j)-sngl(wi)*data(j+1)
+            tempi=sngl(wr)*data(j+1)+sngl(wi)*data(j)
+            data(j)=data(i)-tempr
+            data(j+1)=data(i+1)-tempi
+            data(i)=data(i)+tempr
+            data(i+1)=data(i+1)+tempi
+12        continue
+          wtemp=wr
+          wr=wr*wpr-wi*wpi+wr
+          wi=wi*wpr+wtemp*wpi+wi
+13      continue
+        mmax=istep
+      goto 2
+      endif
+      return
+      END
+C  (C) Copr. 1986-92 Numerical Recipes Software ,5W"1.UY.
+c======================================================================
+c
+      SUBROUTINE rlft3(data,speq,nn1,nn2,nn3,isign)
+      implicit NONE
+      INTEGER isign,nn1,nn2,nn3
+      COMPLEX data(nn1/2,nn2,nn3),speq(nn2,nn3)
+c USES fourn
+      INTEGER i1,i2,i3,j1,j2,j3,nn(3)
+      DOUBLE PRECISION theta,wi,wpi,wpr,wr,wtemp
+      COMPLEX c1,c2,h1,h2,w
+      c1=cmplx(0.5,0.0)
+      c2=cmplx(0.0,-0.5*isign)
+      theta=6.28318530717959d0/dble(isign*nn1)
+      wpr=-2.0d0*sin(0.5d0*theta)**2
+      wpi=sin(theta)
+      nn(1)=nn1/2
+      nn(2)=nn2
+      nn(3)=nn3
+      if(isign.eq.1)then
+        call fourn(data,nn,3,isign)
+        do i3=1,nn3
+        do i2=1,nn2
+            speq(i2,i3)=data(1,i2,i3)
+        enddo
+        enddo
+      endif
+      do i3=1,nn3
+        j3=1
+        if (i3.ne.1) j3=nn3-i3+2
+        wr=1.0d0
+        wi=0.0d0
+        do i1=1,nn1/4+1
+          j1=nn1/2-i1+2
+          do i2=1,nn2
+            j2=1
+            if (i2.ne.1) j2=nn2-i2+2
+            if(i1.eq.1)then
+              h1=c1*(data(1,i2,i3)+conjg(speq(j2,j3)))
+              h2=c2*(data(1,i2,i3)-conjg(speq(j2,j3)))
+              data(1,i2,i3)=h1+h2
+              speq(j2,j3)=conjg(h1-h2)
+            else
+              h1=c1*(data(i1,i2,i3)+conjg(data(j1,j2,j3)))
+              h2=c2*(data(i1,i2,i3)-conjg(data(j1,j2,j3)))
+              data(i1,i2,i3)=h1+w*h2
+              data(j1,j2,j3)=conjg(h1-w*h2)
+            endif
+          enddo
+          wtemp=wr
+          wr=wr*wpr-wi*wpi+wr
+          wi=wi*wpr+wtemp*wpi+wi
+          w=cmplx(sngl(wr),sngl(wi))
+        enddo
+      enddo
+      if(isign.eq.-1)then
+        call fourn(data,nn,3,isign)
+      endif
+      return
+      END
+c
+c======================================================================
+      SUBROUTINE fourn(data,nn,ndim,isign)
+      implicit NONE
+      INTEGER isign,ndim,nn(ndim)
+      REAL data(*)
+      INTEGER i1,i2,i2rev,i3,i3rev,ibit,idim,ifp1,ifp2,ip1,ip2,ip3,k1,
+     *k2,n,nprev,nrem,ntot
+      REAL tempi,tempr
+      DOUBLE PRECISION theta,wi,wpi,wpr,wr,wtemp
+      ntot=1
+      do idim=1,ndim
+        ntot=ntot*nn(idim)
+      enddo
+      nprev=1
+      do idim=1,ndim
+        n=nn(idim)
+        nrem=ntot/(n*nprev)
+        ip1=2*nprev
+        ip2=ip1*n
+        ip3=ip2*nrem
+        i2rev=1
+        do i2=1,ip2,ip1
+          if(i2.lt.i2rev)then
+            do i1=i2,i2+ip1-2,2
+              do i3=i1,ip3,ip2
+                i3rev=i2rev+i3-i2
+                tempr=data(i3)
+                tempi=data(i3+1)
+                data(i3)=data(i3rev)
+                data(i3+1)=data(i3rev+1)
+                data(i3rev)=tempr
+                data(i3rev+1)=tempi
+              enddo
+            enddo
+          endif
+          ibit=ip2/2
+1         if ((ibit.ge.ip1).and.(i2rev.gt.ibit)) then
+            i2rev=i2rev-ibit
+            ibit=ibit/2
+            goto 1
+          endif
+          i2rev=i2rev+ibit
+        enddo
+        ifp1=ip1
+2       if(ifp1.lt.ip2)then
+          ifp2=2*ifp1
+          theta=isign*6.28318530717959d0/(ifp2/ip1)
+          wpr=-2.d0*sin(0.5d0*theta)**2
+          wpi=sin(theta)
+          wr=1.d0
+          wi=0.d0
+          do i3=1,ifp1,ip1
+            do i1=i3,i3+ip1-2,2
+              do i2=i1,ip3,ifp2
+                k1=i2
+                k2=k1+ifp1
+                tempr=sngl(wr)*data(k2)-sngl(wi)*data(k2+1)
+                tempi=sngl(wr)*data(k2+1)+sngl(wi)*data(k2)
+                data(k2)=data(k1)-tempr
+                data(k2+1)=data(k1+1)-tempi
+                data(k1)=data(k1)+tempr
+                data(k1+1)=data(k1+1)+tempi
+              enddo
+            enddo
+            wtemp=wr
+            wr=wr*wpr-wi*wpi+wr
+            wi=wi*wpr+wtemp*wpi+wi
+          enddo
+          ifp1=ifp2
+          goto 2
+        endif
+        nprev=n*nprev
+      enddo
+      return
+      END
+c
+c    ===============================================
+c    inverse cdf of rayleigh distribution
+c    y=sigma*sqrt(-2ln(1-F)), F is cdf of rayleigh distribution
+c
+      Function irayl(f,sigma)
+       implicit NONE
+       real f,irayl,sigma
+       if(f.ge.0.0.and.f.lt.1.0)then
+         irayl=sigma*sqrt(-2.0*log(1.0-f))
+       else
+         write(*,*)"input error cumlative cdf must within (0,1)"
+         write(*,*)"input F= ",f
+         stop
+       endif
+      END
+c
+c======================================================================
+c     rayleigh distribution: (x/sigma^2)exp(-x^2/(2sigma^2))
+c     cdf is 1-exp(-x^2/(2sigma^2))
+c     mean is 1.253*sigma
+c     mode is sigma
+c     95% of cdf at x~2.448*sigma
+c
+      Function rayleigh(idum,sigma)
+      implicit NONE
+      integer idum
+      real rayleigh,u,sigma,ran3
+      u=ran3(idum)
+      rayleigh=sigma*sqrt(-2.0*log(u))
+      return
+      END
+c
+c======================================================================
+      FUNCTION gasdev(idum,iset)
+      implicit NONE
+      INTEGER idum
+      REAL gasdev
+CU    USES ran3
+      INTEGER iset
+      REAL fac,gset,rsq,v1,v2,ran3
+      SAVE gset
+      if (iset.eq.0) then
+1       v1=2.*ran3(idum)-1.
+        v2=2.*ran3(idum)-1.
+        rsq=v1**2+v2**2
+        if(rsq.ge.1..or.rsq.eq.0.)goto 1
+        fac=sqrt(-2.*log(rsq)/rsq)
+        gset=v1*fac
+        gasdev=v2*fac
+        iset=1
+      else
+        gasdev=gset
+        iset=0
+      endif
+      return
+      END
+c
+c======================================================================
+C
+      FUNCTION gammln(xx)
+      implicit NONE
+      REAL gammln,xx
+      INTEGER j
+      DOUBLE PRECISION ser,stp,tmp,x,y,cof(6)
+      SAVE cof,stp
+      DATA cof,stp/76.18009172947146d0,-86.50532032941677d0,
+     *24.01409824083091d0,-1.231739572450155d0,.1208650973866179d-2,
+     *-.5395239384953d-5,2.5066282746310005d0/
+      x=xx
+      y=x
+      tmp=x+5.5d0
+      tmp=(x+0.5d0)*log(tmp)-tmp
+      ser=1.000000000190015d0
+      do j=1,6
+        y=y+1.d0
+        ser=ser+cof(j)/y
+      enddo
+      gammln=tmp+log(stp*ser/x)
+      return
+      END
+c
+c======================================================================
+c
+      FUNCTION betafn(z,w)
+      implicit NONE
+      REAL betafn,z,w
+c  USES gammln
+      REAL gammln
+      betafn=exp(gammln(z)+gammln(w)-gammln(z+w))
+      return
+      END
+c
+c======================================================================
+c calculate the cumulative probability density related to x
+        subroutine gasprb(v2p,n)
+c  gasprb=1.0-0.5*erfcc(x/sqrt(2))
+        implicit NONE
+        integer n,i
+        real v2p(n),sum1,sum2,xx,avg,std,prb,x,z,t
+
+        sum1=0.0
+        sum2=0.0
+        do i=1,n
+          xx=v2p(i)
+          sum1=sum1+xx
+          sum2=sum2+xx*xx
+        enddo
+        avg=sum1/float(n)
+        std=sqrt(sum2/float(n)-avg*avg)
+        do i=1,n
+          v2p(i)=(v2p(i)-avg)/std
+        enddo
+
+        do i=1,n
+          x=v2p(i)
+          z=abs(x*0.70710678)
+          t=1./(1.+0.5*z)
+          prb=0.5*t*exp(-z*z-1.26551223+t*(1.00002368+t*(.37409196+
+     *       t*(.09678418+t*(-.18628806+t*(.27886807+t*(-1.13520398+
+     *       t*(1.48851587+t*(-.82215223+t*.17087277)))))))))
+          if(x.gt.0.0) prb=1.-prb
+
+          v2p(i)=prb
+        enddo
+        return
+        END
+
+c
+c======================================================================
+c
+        FUNCTION ran3(idum)
+c ROUTINE TO GENERATE A UNIFORMLY DISTRIBUTED RANDOM
+c NUMBER ON THE INTERVAL [0,1].
+c
+        implicit NONE
+        INTEGER idum,IA,IM,IQ,IR,NTAB,NDIV
+        REAL ran3,AM,EPS,RNMX
+        PARAMETER (IA=16807,IM=2147483647,AM=1./IM,IQ=127773,IR=2836,
+     *  NTAB=32,NDIV=1+(IM-1)/NTAB,EPS=1.2e-7,RNMX=1.-EPS)
+        INTEGER j,k,iv(NTAB),iy
+        SAVE iv,iy
+        DATA iv /NTAB*0/, iy /0/
+        if (idum.le.0.or.iy.eq.0) then
+          idum=max(-idum,1)
+          do 11 j=NTAB+8,1,-1
+            k=idum/IQ
+            idum=IA*(idum-k*IQ)-IR*k
+            if (idum.lt.0) idum=idum+IM
+            if (j.le.NTAB) iv(j)=idum
+11        continue
+          iy=iv(1)
+        endif
+        k=idum/IQ
+        idum=IA*(idum-k*IQ)-IR*k
+        if (idum.lt.0) idum=idum+IM
+        j=1+iy/NDIV
+        iy=iv(j)
+        iv(j)=idum
+        ran3=min(AM*iy,RNMX)
+        return
+        END
+
+c
+c======================================================================
+c
+c The following subroutine were provided by Dan O'Connell.
+c
+c======================================================================
+c
+      SUBROUTINE XZPTIM(time,slow,mxx,nx,nz,H,sx,sz,rtime,rtx,rtz,nreq)
+      IMPLICIT NONE
+      INTEGER  NX, NZ, ISZ, ISX, I, J, ILEFT, IRIGHT,
+     &     ITOP, IBOT, mxx, ifirst, iimax, jimax, ltop,lbot, lleft,
+     &     lright, isxm1, iszm1, isxp1,iszp1, irevc, irevr, ictop,
+     &     icbot, idum,nreq
+      INTEGER nx1,nz1, ifrstc,ifrstr
+C
+C ... source position and grid boundaries
+      REAL SX,SZ,xmin,xmax,zmin,zmax, difmax, dist, testv, htime,
+     &     dif,perc
+C ... grid spacing and constants to reduce redundant calculations
+      REAL H,H2,HTSQR2,HS2I,sval
+C ... Variables of interest
+      REAL TIME( mxx,nz), SLOW( mxx,nz ), rtime(1:*),rtx(1:*),rtz(1:*)
+      H2 = H * H
+      HTSQR2 = H * SQRT(2.0)
+      HS2I = H / SQRT(2.0)
+C
+C ... Initialize travel-time array to big value
+      DO I = 1, NZ
+         DO J = 1, NX
+            time(J,I) = 1.E10
+         enddo
+      enddo
+C
+C---- calculate grid boundaries
+      xmin = 0.0
+      zmin = 0.0
+      nx1 = nx - 1
+      nz1 = nz - 1
+      xmax = float(nx1) * H
+      zmax = float(nz1) * H
+C
+C .... Source position cannot be on or outside grid edge
+      IF( SX .LT. XMIN .OR. SX .GT. XMAX .OR. SZ .LT. ZMIN
+     &     .OR. SZ .GT. ZMAX) THEN
+         PRINT *,' SOURCE OUTSIDE GRID.'
+         stop
+      endif
+C
+C---- CALCULATE CLOSEST GRID POINT TO SOURCE
+      ISX = 1 + NINT((SX - XMIN)/H)
+      ISZ = 1 + NINT((SZ - ZMIN)/H)
+C
+C ... Initialize source point using polar scheme out to 10 x-z rings
+      CALL pintim(sx,sz,h,h,nx,nz,slow,mxx,time)
+C
+C ... Initialize starting positions so that corners of rows and columns
+C ... overlap
+      iszm1 = ISZ - 1
+      ITOP = MAX(1,iszm1-1)
+      iszp1 = ISZ + 1
+      IBOT = min(nz,iszp1+1)
+      isxm1 = ISX - 1
+      ILEFT = max(isxm1-1,1)
+      isxp1 = ISX + 1
+      IRIGHT = min(nx,isxp1+1)
+C
+C---- set activity flags
+      LLEFT = 1
+      LRIGHT = 1
+      LTOP = 1
+      LBOT = 1
+C
+C---- check for edges that are already inactive due to source location
+      IF (ILEFT .eq. 1) LLEFT = 0
+      IF (IRIGHT .eq. nx) LRIGHT = 0
+      IF (ITOP .eq. 1) LTOP = 0
+      IF (IBOT .eq. nz) LBOT = 0
+C
+C---- calculate until the entire grid is filled with times
+      do while (LLEFT .NE. 0 .OR. LRIGHT .NE. 0 .OR. LTOP .NE. 0 .OR.
+     &     LBOT .NE. 0)
+C
+C ...... Initialize refraction flag to false
+         ifirst = 0
+         ictop = 0
+         icbot = 0
+C
+C ...... Solve for column at left
+         IF( LLEFT .NE. 0 ) THEN
+            ifirst=1
+            do while (ifirst .ne. 0)
+               ifirst=0
+               CALL COLTIM(time,slow,mxx,nx,nz,ILEFT,ITOP,IBOT,-1,
+     &              0,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+C
+C---------- check for refraction and the need to reverse the calculation
+               if (ifirst .ne. 0) then
+C
+C---------------- fill out rows to give values to uninitiazed points
+                  IF( LTOP .NE. 0 .and. ictop .ne. 0) THEN
+                     idum = -1
+                     CALL ROWTIM(time,slow,mxx,nx,nz,ITOP,ILEFT,IRIGHT,
+     &                    -1,-1,idum,nx1,nz1,h,h2,HTSQR2,HS2I)
+                     ictop = 0
+                  endif
+                  IF( LBOT .NE. 0 .and. icbot .ne. 0) THEN
+                     idum = -1
+                     CALL ROWTIM(time,slow,mxx,nx,nz,IBOT,ILEFT,IRIGHT,
+     &                    1,-1,idum,nx1,nz1,h,h2,HTSQR2,HS2I)
+                     icbot = 0
+                  endif
+C
+C------------- reverse, starting column is the one just calculated
+                  irevc = ileft + 1
+                  do while (ifirst .ne. 0 .and. irevc .lt. isxm1)
+                     ifirst = 0
+                     call COLTIM(time,slow,mxx,nx,nz,irevc,ITOP,IBOT,1,
+     &                    1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+                     irevc = irevc+1
+                  enddo
+C
+C------------- reverse again to get to starting position
+                  do i=irevc-2,ileft,-1
+                     call COLTIM(time,slow,mxx,nx,nz,i,ITOP,IBOT,-1,
+     &                    -1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+                  enddo
+               endif
+            enddo
+C
+C---------- if we have hit this edge set its flag inactive
+            IF (ILEFT .eq. 1) LLEFT = 0
+         ENDIF
+C
+C ...... Solve for column at right
+         IF( LRIGHT .NE. 0 ) THEN
+            ifirst=1
+            do while (ifirst .ne. 0)
+               ifirst=0
+               CALL COLTIM(time,slow,mxx,nx,nz,iright,ITOP,IBOT,1,
+     &              0,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+C
+C------------- check for refraction and the need to reverse the calculation
+               if (ifirst .ne. 0) then
+C
+C---------------- fill out rows to give values to uninitiazed points
+                  IF( LTOP .NE. 0 .and. ictop .ne. 0) THEN
+                     idum = -1
+                     CALL ROWTIM(time,slow,mxx,nx,nz,ITOP,ILEFT,IRIGHT,
+     &                    -1,-1,idum,nx1,nz1,h,h2,HTSQR2,HS2I)
+                     ictop = 0
+                  endif
+                  IF( LBOT .NE. 0 .and. icbot .ne. 0) THEN
+                     idum = -1
+                     CALL ROWTIM(time,slow,mxx,nx,nz,IBOT,ILEFT,IRIGHT,
+     &                    1,-1,idum,nx1,nz1,h,h2,HTSQR2,HS2I)
+                     icbot = 0
+                  endif
+c                  print *,'reverse right ',iright
+C
+C---------------- reverse, starting column is the one just calculated
+                  irevc = iright-1
+                  do while (ifirst .ne. 0 .and. irevc .gt. isxp1)
+                     ifirst = 0
+                     call COLTIM(time,slow,mxx,nx,nz,irevc,ITOP,IBOT,-1,
+     &                    1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+c                     print *,' reversing right at ',iright,irevc
+                     irevc = irevc-1
+                  enddo
+C
+C---------------- reverse again to get to starting position
+                  do i=irevc+2,iright
+                     call COLTIM(time,slow,mxx,nx,nz,i,ITOP,IBOT,1,
+     &                    -1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+                  enddo
+               endif
+            enddo
+C
+C---------- if we have hit this edge set its flag inactive
+            IF (IRIGHT .eq. nx) LRIGHT = 0
+         ENDIF
+C
+C ...... Solve row at top
+         IF( LTOP .NE. 0 ) THEN
+            ifirst=1
+            do while (ifirst .ne. 0)
+               ifirst=0
+               CALL ROWTIM(time,slow,mxx,nx,nz,ITOP,ILEFT,IRIGHT,-1,
+     &              0,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+C
+C---------- check for refraction and the need to reverse the calculation
+               if (ifirst .ne. 0) then
+C
+C------------- reverse, starting row is the one just calculated
+                  irevr = itop+1
+                  do while (ifirst .ne. 0 .and. irevr .lt. iszm1)
+                     ifirst = 0
+                     CALL ROWTIM(time,slow,mxx,nx,nz,irevr,ILEFT,IRIGHT,
+     &                    1,1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+                     irevr = irevr+1
+                  enddo
+C
+C------------- reverse again to get to starting position
+                  do i=irevr-2,itop,-1
+                     CALL ROWTIM(time,slow,mxx,nx,nz,i,ILEFT,IRIGHT,-1,
+     &                    -1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+                  enddo
+               endif
+            enddo
+C
+C---------- if we have hit this edge set its flag inactive
+            IF (ITOP .eq. 1) LTOP = 0
+         ENDIF
+C ...... Solve row at bottom
+         IF( LBOT .NE. 0 ) THEN
+            ifirst=1
+            do while (ifirst .ne. 0)
+               ifirst=0
+               CALL ROWTIM(time,slow,mxx,nx,nz,IBOT,ILEFT,IRIGHT,1,
+     &              0,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+C
+C------------- check for refraction and the need to reverse the calculation
+               if (ifirst .ne. 0) then
+c                  print *,'reverse bot ',ibot
+C
+C---------------- reverse, starting row is the one just calculated
+                  irevr = ibot-1
+                  do while (ifirst .ne. 0 .and. irevr .gt. iszp1)
+                     ifirst = 0
+                     CALL ROWTIM(time,slow,mxx,nx,nz,irevr,ILEFT,IRIGHT,
+     &                    -1,1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+c                     print *,'reversing bot at',ibot,irevr
+                     irevr = irevr-1
+                  enddo
+C
+C---------------- reverse again to get to starting position
+                  do i=irevr+1,ibot
+                     CALL ROWTIM(time,slow,mxx,nx,nz,i,ILEFT,IRIGHT,1,
+     &                    -1,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+                  enddo
+               endif
+            enddo
+C
+C---------- if we have hit this edge set its flag inactive
+            IF (IBOT .eq. nz) LBOT = 0
+         ENDIF
+
+C ...... Increment rows and columns that have advanced or set inactive flags
+         IF( ILEFT .GT. 1 ) ILEFT = ILEFT - 1
+         IF( IRIGHT .lt. nx ) IRIGHT = IRIGHT + 1
+         IF( iTOP .gt. 1 ) ITOP = ITOP - 1
+         IF( iBOT .lt. nz ) IBOT = IBOT + 1
+C
+C ... Continue calculation until all grid boundaries are found
+      enddo
+C
+C ... The grid is now filled with travel times
+c      print *,' entire grid filled with travel times.'
+C
+C---- compute requested travel-times
+      call inttrt(h,time,slow,mxx,nx,nz,sx,sz,rtx,rtz,rtime,nreq)
+C
+C ... write out travel-time field
+c      open(8,file='ttest.bin',status='unknown',form='unformatted')
+c      write(8) nx,nz,1./slow(1,1),h
+c      write(8) ((time(j,i),j=1,nx),i=1,nz)
+c      close(8)
+      return
+      END
+c
+c======================================================================
+c
+      subroutine pintim(xsrc,zsrc,dx,dz,nx,nz,sloxz,mxx,timexz)
+C
+C     PINTIM calculates travel times on a polar grid centered on the source
+C     position within 2-D cartesian grid of slowesses and interpolates the
+C     calculated times onto the portion of the 2-D cartesian grid near the
+C     source which provides an accurate initiazation to start the cartesian
+C     finite difference propagation of travel times. The parameter SISIZE
+C     determines how far into the cartesian grid the polar grid expands from
+C     the source point. If SISIZE is increased, MXP (maximum number of angles)
+C     and MXR (maximum number of radii) must be increased. As r increases
+C     the angle increment must decrease to ensure at least 2 angle increments
+C     within the outermost cartesian cell. These calculations are done in
+C     in subroutine ANGRGN.
+C
+C     Only forward propagation is used since the beginning of head waves
+C     tends to be picked up properly in a polar geometry. Nearly the
+C     entire source region is re-computed in the cartesian finite difference
+C     portion anway, and it does do reverersals. PINTIM calculates the
+C     spherical wavefronts more accurately near the source, providing more
+C     accurate (earlier) times at 45 degrees from the cartesian axes.
+C
+      IMPLICIT NONE
+      INTEGER MXP,MXR
+      PARAMETER (MXP = 200, MXR = 32)
+      integer nx,nz,mxx
+      DOUBLE PRECISION dr,dp,dr2,dr3,dp2,dp2dr2,dp2i,dridpi,drdp22,
+     &     drdp,TIME(MXP,MXR),p(1:mxp),cosp,
+     &     sang(mxp),angstr,angend,cang(mxp),sring(0:mxp,2),
+     &     bigslo,r(0:mxr+1)
+      parameter (bigslo = 20.D0)
+      real xmin,xmax,zmin,zmax,xsrc,zsrc,dx,dz,sloxz(mxx,nz),
+     &     timexz(mxx,nz),SISIZE
+      PARAMETER (SISIZE = 10.)
+      INTEGER I,J,J1,rftest,nr,np,iangr
+C
+C---- setup the limits of the cartesian region to intialize
+C
+      xmin = max(0.0,xsrc - SISIZE*dx)
+      zmin = max(0.0,zsrc - SISIZE*dz)
+      xmax = min(float(nx-1)*dx,xsrc + SISIZE*dx)
+      zmax = min(float(nz-1)*dz,zsrc + SISIZE*dz)
+C
+C---- setup geometry from cartesion to polar travel-time grid
+      call angrgn(xmin,xmax,zmin,zmax,dx,dz,xsrc,zsrc,angstr,angend,
+     &     dr,dp,nr,np,r,p,cang,sang)
+C
+C---- set flag if complete circles are not needed to the endpoints
+C---- of each ring see large slowness
+      if (abs(angend-angstr) .lt. 4.0D0) THEN
+         iangr = 1
+      else
+         iangr = 0
+      endif
+C      print *,'nr,np',nr,np
+C
+C---- call setrng to calculate slownesses for the first two radius rings
+      call setrng(xmin,xmax,zmin,zmax,xsrc,zsrc,bigslo,angstr,angend,
+     &     dx,dz,dr,dp,nr,np,r,p,cang,sang,sring,mxp,sloxz,mxx,
+     &     nx,nz,1,1,iangr)
+C
+C---- PRE-CALCULATE angles, etc
+      cosp=cos(dp)
+C
+C---- PRE-CALCULATE global grid constants
+      call defcon(dr,dp,dr2,dr3,dp2,drdp,dp2dr2,dp2i,dridpi,drdp22)
+C
+C---- INITIALIZE TRAVEL-TIME FIELD TO INFINITY (almost)
+      DO I = 1, nr
+         DO J = 1, np
+            TIME(J,I) = 1.D10
+         enddo
+      enddo
+C
+C---- SETUP SOURCE
+C
+C---- CALCULATE RADIAL TRAVEL-TIMES
+      DO I=1,np
+         TIME(I,1) = dr*min(sring(i-1,1),sring(i,1))
+      ENDDO
+C
+C---- calculate possible refraction times
+C---- sweep to maximum angle
+      rftest = 0
+      CALL REFSWP(1,np-1,TIME,MXP,nr,1,drdp,sring(1,1),
+     &     sring(1,2),1,rftest)
+C---- sweep to minimum angle
+      CALL REFSWP(np,2,TIME,MXP,nr,1,drdp,sring(0,1),
+     &     sring(0,2),-1,rftest)
+C
+C---- end source initialization, start ring loop
+C
+      DO J = 2, nr
+         J1 = J - 1
+C
+C------- call setrng to calculate slownesses for the next radius ring
+         call setrng(xmin,xmax,zmin,zmax,xsrc,zsrc,bigslo,angstr,angend,
+     &        dx,dz,dr,dp,nr,np,r,p,cang,sang,sring,mxp,sloxz,mxx,
+     &        nx,nz,j,0,iangr)
+C
+C------- calculate forward
+         call forwrd(r(j),dr,dp,dr2,dr3,dp2,dp2dr2,dp2i,dridpi,drdp22,
+     &        drdp,cosp,sring,time,mxp,nr,j,j1,rftest,np)
+      enddo
+C
+C---- compute times of nodes of cartesian grid that fall within the
+C---- initialization polar grid
+      call intxzt(dr,dp,r,p,time,mxp,np,nr,xsrc,zsrc,timexz,mxx,nx,nz,
+     &     dx,dz,xmin,xmax,zmin,zmax,iangr)
+      return
+      end
+c
+c======================================================================
+c
+      SUBROUTINE COLTIM(time,slow,mxx,nx,nz,NUMCOL,ITOP,IBOT,
+     &     IWAY,irev,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+C-----------------------------------------------------------------
+C     COLTIM calculates travel times for a column by sweeping up
+C     and down the column for all templates until all points
+C     in the column are filled with minimum travel times.
+C-----------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER MIDIM
+      PARAMETER (MIDIM = 100)
+      INTEGER I, J, J1,K,K1, IWAY, NUMCOL, ITOP, IBOT, IREFS, ifirst,
+     &     ILASTT, INEXTS, mxx, nx, nz,nx1,nz1, IL, IU,irev,ihit, isave,
+     &     nmin,minstr(MIDIM),mnlend(MIDIM), mnuend(MIDIM),indexm(MIDIM)
+      REAL h,h2,HTSQR2,HS2I,S1,S2
+C .... Variables of interest (memory hogs)
+      REAL TIME( mxx, nz), SLOW( mxx, nz ),tmmin(MIDIM)
+C
+C---- calculate inside row positions for time and slowness
+      ILASTT = NUMCOL - IWAY
+C
+C---- make sure slowness index matches column position and increment direction
+      IF (IWAY .LT. 0) THEN
+         INEXTS = MAX(1,MIN(NUMCOL,nx1))
+      ELSE
+         INEXTS = MAX(1,MIN(ILASTT,NX1))
+      ENDIF
+C
+C---- extend base to outer end to ensure a complete base to step forward
+      ihit = 0
+      IF (IREV .eq. 0) THEN
+C
+C------- find positions of time minima to order refraction loops below
+         call fndcmn(time,mxx,nz,ILASTT,itop,ibot,nmin,minstr,mnlend,
+     &        mnuend,tmmin,indexm)
+         IREFS = MAX(1,MIN(INEXTS-IWAY,nx1))
+         isave = 0
+C
+C--------loop through number minimum times found
+         do i = 1,nmin
+C
+C---------- loop down
+            do j = minstr(indexm(I)),mnuend(indexm(I))
+               j1 = J + 1
+               IU = MIN(J,nz1)
+               ihit = 0
+               call reftim(time(ILASTT,j),time(ILASTT,j1),
+     &              slow(INEXTS,IU),slow(IREFS,IU),H,ihit)
+C
+C---------- if a refraction occurs sweep to the end of this column
+               if (ihit .ne. 0) then
+                  ifirst = 1
+                  do k=j+1,ibot-1
+                     k1 = k+1
+                     IU = MIN(k,nz1)
+                     call reftim(time(ILASTT,k),time(ILASTT,k1),
+     &                    slow(INEXTS,IU),slow(IREFS,IU),H,ihit)
+                  enddo
+               endif
+            enddo
+C
+C---------- bottom to top
+            do j = minstr(indexm(I)), mnlend(indexm(I)),-1
+               j1 = j - 1
+               IU = MIN(J1,nz1)
+               ihit = 0
+               call reftim(time(ILASTT,j),time(ILASTT,j1),
+     &              slow(INEXTS,IU),slow(IREFS,IU),H,ihit)
+C
+C------------- if a refraction occurs sweep to the end of this column
+               if (ihit .ne. 0) then
+                  ifirst = 1
+                  do k=j-1,itop+1,-1
+                     k1 = k-1
+                     IU = MIN(k1,nz1)
+                     call reftim(time(ILASTT,k),time(ILASTT,k1),
+     &                    slow(INEXTS,IU),slow(IREFS,IU),H,ihit)
+                  enddo
+               endif
+            enddo
+         enddo
+C
+C------- if a refractor was found, return to do reverse propagation
+         if (ifirst .ne. 0) return
+      endif
+C
+      ihit = 0
+C
+C---- find positions of time minima to order transmission loops below
+      call fndcmn(time,mxx,nz,ILASTT,itop,ibot,nmin,minstr,mnlend,
+     &     mnuend,tmmin,indexm)
+C
+C---- 2d refraction outer slowness index
+      IREFS = MAX(1,MIN(INEXTS+IWAY,NX1))
+C
+C---- sweep out from minimum time(s)
+      do i = 1,nmin
+C
+C ...... calculate 1D transmission time at minima
+         J = minstr(indexm(I))
+         IL = MAX(1,J-1)
+         IU = MIN(J,nz1)
+C
+C------- kludge to make sure a lower time is indicated during a reversal
+         IF (slow(INEXTS,IU) .lt. slow(INEXTS,IL)) then
+            s1 = slow(INEXTS,IU)
+            s2 = slow(INEXTS,IL)
+         else
+            s1 = slow(INEXTS,IL)
+            s2 = slow(INEXTS,IU)
+         endif
+         call reftim(TIME(ILASTT,J),TIME(NUMCOL,J),s1,s2,H,ihit)
+C
+C ...... start up from the bottom
+         do j = minstr(indexm(I)), mnlend(indexm(I)),-1
+            J1 = J - 1
+            IL = MAX(1,J1-1)
+            IU = max(1,J1)
+C
+C---------- kludge to make sure a lower time is indicated during a reversal
+            IF (slow(INEXTS,IU) .lt. slow(INEXTS,IL)) then
+               s1 = slow(INEXTS,IU)
+               s2 = slow(INEXTS,IL)
+            else
+               s1 = slow(INEXTS,IL)
+               s2 = slow(INEXTS,IU)
+            endif
+C
+C---------- calculate refraction orthogonal to column
+            call reftim(TIME(ILASTT,J1),TIME(NUMCOL,J1),s1,s2,H,ihit)
+C
+C---------- 2d diffraction
+            call diftim(TIME(ILASTT,J),TIME(NUMCOL,J1),slow(INEXTS,IU),
+     &           HTSQR2,IHIT)
+C
+C---------- 2d transmission from base
+            call trntim(TIME(ILASTT,J),TIME(ILASTT,J1),TIME(NUMCOL,J),
+     &           TIME(NUMCOL,J1),slow(INEXTS,IU),h2,hs2i,ihit,irev)
+C
+C---------- 2d transmission from side
+            call trntim(TIME(ILASTT,J),TIME(NUMCOL,J),TIME(ILASTT,J1),
+     &           TIME(NUMCOL,J1),slow(INEXTS,IU),h2,hs2i,ihit,irev)
+            isave = 0
+C
+C---------- edge refraction
+            call reftim(time(NUMCOL,j),time(NUMCOL,j1),
+     &              slow(IREFS,IU),slow(INEXTS,IU),H,isave)
+C
+C---------- if a refraction occurs sweep to the end of this column
+            if (isave .ne. 0) then
+               ifirst = 1
+               do k=j-1,itop+1,-1
+                  k1 = k-1
+                  IU = max(1,k1)
+                  call reftim(time(NUMCOL,k),time(NUMCOL,k1),
+     &                 slow(IREFS,IU),slow(INEXTS,IU),H,ihit)
+               enddo
+            endif
+         enddo
+         do j = minstr(indexm(I)),mnuend(indexm(I))
+            J1 = J + 1
+            IL = MIN(j1,nz1)
+            IU = MIN(J,nz1)
+C
+C---------- kludge to make sure a lower time is indicated during a reversal
+            IF (slow(INEXTS,IU) .lt. slow(INEXTS,IL)) then
+               s1 = slow(INEXTS,IU)
+               s2 = slow(INEXTS,IL)
+            else
+               s1 = slow(INEXTS,IL)
+               s2 = slow(INEXTS,IU)
+            endif
+C
+C---------- calculate refraction orthogonal to column
+            call reftim(TIME(ILASTT,J1),TIME(NUMCOL,J1),s1,s2,H,ihit)
+C
+C---------- 2d diffraction
+            call diftim(TIME(ILASTT,J),TIME(NUMCOL,J1),slow(INEXTS,IU),
+     &           HTSQR2,IHIT)
+C
+C---------- 2d transmission from base
+            call trntim(TIME(ILASTT,J),TIME(ILASTT,J1),TIME(NUMCOL,J),
+     &           TIME(NUMCOL,J1),slow(INEXTS,IU),h2,hs2i,ihit,irev)
+C
+C---------- 2d transmission from side
+            call trntim(TIME(ILASTT,J),TIME(NUMCOL,J),TIME(ILASTT,J1),
+     &           TIME(NUMCOL,J1),slow(INEXTS,IU),h2,hs2i,ihit,irev)
+            isave = 0
+            call reftim(time(NUMCOL,j),time(NUMCOL,j1),
+     &           slow(IREFS,IU),slow(INEXTS,IU),H,isave)
+C
+C---------- if a refraction occurs sweep to the end of this column
+            if (isave .ne. 0) then
+               ifirst = 1
+               do k=j+1,ibot-1
+                  k1 = k+1
+                  IU = MIN(k,nz1)
+                  call reftim(time(NUMCOL,k),time(NUMCOL,k1),
+     &                 slow(IREFS,IU),slow(INEXTS,IU),H,ihit)
+               enddo
+            endif
+         enddo
+      enddo
+C
+C---- if in the process of reversing, indicate if any times were reduced
+      if (irev .ne. 0) ifirst = max(ifirst,ihit)
+      return
+      END
+c
+c======================================================================
+c
+      SUBROUTINE rowTIM(time,slow,mxx,nx,nz,NUMrow,ileft,iright,
+     &     IWAY,irev,ifirst,nx1,nz1,h,h2,HTSQR2,HS2I)
+C-----------------------------------------------------------------
+C     ROWTIM calculates travel times for a row by sweeping left
+C     and right across the row for all templates until all points
+C     in the row are filled with minimum travel times.
+C-----------------------------------------------------------------
+      IMPLICIT NONE
+      INTEGER MIDIM
+      PARAMETER (MIDIM = 100)
+      INTEGER I,J, J1,K,K1, IWAY, numrow, ileft, iright, IREFS, IL, IU,
+     &     ILASTT, INEXTS, mxx, nx, nz,nx1,nz1, ifirst, irev,ihit,isave,
+     &     nmin,minstr(MIDIM),mnlend(MIDIM), mnuend(MIDIM),indexm(MIDIM)
+      REAL h,h2,HTSQR2,HS2I,S1,S2
+C ... Variables of interest (memory hogs)
+      REAL TIME( mxx, nz), SLOW( mxx, nz ),tmmin(MIDIM)
+C
+C---- calculate row positions for time and slowness
+      ILASTT = NUMROW - IWAY
+C
+C---- make sure slowness index matches row position and increment direction
+      IF (IWAY .LT. 0) THEN
+         INEXTS = MAX(1,MIN(numrow,nz1))
+      ELSE
+         INEXTS = MAX(1,MIN(ILASTT,Nz1))
+      ENDIF
+C
+C---- extend base to bottom of corners to complete ensure a complete base
+      ihit = 0
+      IF (IREV .LE. 0) THEN
+C
+C------- find positions of time minima to order refraction loops below
+         call fndrmn(time,mxx,nz,ILASTT,ileft,iright,nmin,minstr,mnlend,
+     &        mnuend,tmmin,indexm)
+         IREFS = MAX(1,MIN(INEXTS-IWAY,NZ1))
+         isave = 0
+C
+C------- loop through number minimum times found
+         do i = 1,nmin
+C
+C---------- left to right
+            do j = minstr(indexm(I)),mnuend(indexm(I))
+               j1 = J + 1
+               IU = MIN(J,nx1)
+               ihit = 0
+               call reftim(time(j,ILASTT),time(j1,ILASTT),
+     &              slow(iu,INEXTS),slow(iu,IREFS),H,ihit)
+C
+C------------- if a refraction occurs sweep to the end of this row
+               if (ihit .ne. 0) then
+                  ifirst = 1
+                  do k=j+1,iright-1
+                     k1 = k+1
+                     IU = MIN(k,nx1)
+                     call reftim(time(k,ILASTT),time(k1,ILASTT),
+     &                    slow(iu,INEXTS),slow(iu,IREFS),H,ihit)
+                  enddo
+               endif
+            enddo
+C
+C---------- right to left
+            do j = minstr(indexm(I)), mnlend(indexm(I)),-1
+               j1 = j - 1
+               IU = MIN(J1,nx1)
+               ihit = 0
+               call reftim(time(j,ILASTT),time(j1,ILASTT),
+     &              slow(iu,INEXTS),slow(iu,IREFS),H,ihit)
+C
+C------------- if a refraction occurs sweep to the end of this row
+               if (ihit .ne. 0) then
+                  ifirst = 1
+                  do k=j-1,ileft+1,-1
+                     k1 = k-1
+                     IU = MIN(k,nx1)
+                     call reftim(time(k,ILASTT),time(k1,ILASTT),
+     &                    slow(iu,INEXTS),slow(iu,IREFS),H,ihit)
+                  enddo
+               endif
+            enddo
+         enddo
+C
+C------- if a refractor was found, return to do reverse propagation
+         if (ifirst .ne. 0) return
+      ENDIF
+      ihit = 0
+C
+C---- find positions of time minima to order transmission loops below
+      call fndrmn(time,mxx,nz,ILASTT,ileft,iright,nmin,minstr,mnlend,
+     &     mnuend,tmmin,indexm)
+C
+C---- 2d refraction outer slowness index
+      IREFS = MAX(1,MIN(INEXTS+IWAY,NZ1))
+C
+C---- sweep out from minimum time(s)
+      do i = 1,nmin
+C
+C ...... calculate 1D transmission time
+         J = minstr(indexm(i))
+         IL = MAX(1,J-1)
+         IU = MIN(J,nx1)
+C
+C------- kludge to make sure a lower time is indicated during a reversal
+         if (slow(iu,INEXTS) .lt. slow(il,INEXTS)) then
+            s1 = slow(iu,INEXTS)
+            s2 = slow(il,INEXTS)
+         else
+            s2 = slow(iu,INEXTS)
+            s1 = slow(il,INEXTS)
+         endif
+         call reftim(TIME(j,ilastt),TIME(j,numrow),s1,s2,H,ihit)
+C
+C------- right to left
+         do j = minstr(indexm(I)), mnlend(indexm(I)),-1
+            j1 = j - 1
+            IL = max(1,j1-1)
+            IU = max(1,J1)
+C
+C---------- kludge to make sure a lower time is indicated during a reversal
+            if (slow(iu,INEXTS) .lt. slow(il,INEXTS)) then
+               s1 = slow(iu,INEXTS)
+               s2 = slow(il,INEXTS)
+            else
+               s2 = slow(iu,INEXTS)
+               s1 = slow(il,INEXTS)
+            endif
+C
+C---------- calculate refraction orthogonal to row
+            call reftim(TIME(j1,ilastt),TIME(j1,numrow),s1,s2,H,ihit)
+C
+C---------- 2d diffraction
+            call diftim(time(j,ilastt),time(j1,numrow),slow(iu,inexts),
+     &           HTSQR2,IHIT)
+C
+C---------- 2d transmission from base
+            call trntim(TIME(j,ilastt),TIME(j1,ilastt),TIME(j,numrow),
+     &           TIME(j1,numrow),slow(iu,INEXTS),h2,hs2i,ihit,irev)
+C
+C---------- 2d transmission from side
+            call trntim(TIME(j,ilastt),TIME(j,numrow),TIME(j1,ilastt),
+     &           TIME(j1,numrow),slow(iu,INEXTS),h2,hs2i,ihit,irev)
+            isave = 0
+C
+C---------- edge refraction
+            call reftim(time(j,numrow),time(j1,numrow),
+     &           slow(iu,IREFS),slow(iu,INEXTS),H,isave)
+C
+C---------- if a refraction occurs sweep to the end of this row
+            if (isave .ne. 0) then
+               ifirst = 1
+               do k=j-1,ileft+1,-1
+                  k1 = k-1
+                  IU = max(1,k1)
+                  call reftim(time(k,numrow),time(k1,numrow),
+     &                 slow(iu,IREFS),slow(iu,INEXTS),H,ihit)
+               enddo
+            endif
+         enddo
+C
+C------- sweep from left to right
+         do j = minstr(indexm(I)),mnuend(indexm(I))
+            J1 = J + 1
+            IL = min(j1,nx1)
+            IU = MIN(J,nx1)
+C
+C---------- kludge to make sure a lower time is indicated during a reversal
+            if (slow(iu,INEXTS) .lt. slow(il,INEXTS)) then
+               s1 = slow(iu,INEXTS)
+               s2 = slow(il,INEXTS)
+            else
+               s2 = slow(iu,INEXTS)
+               s1 = slow(il,INEXTS)
+            endif
+C
+C---------- calculate refraction orthogonal to row
+            call reftim(TIME(j1,ilastt),TIME(j1,numrow),s1,s2,H,ihit)
+C
+C---------- 2d diffraction
+            call diftim(TIME(j,ilastt),TIME(j1,numrow),slow(IU,INEXTS),
+     &           HTSQR2,IHIT)
+C
+C---------- 2d transmission from base
+            call trntim(TIME(j,ilastt),TIME(j1,ilastt),TIME(j,numrow),
+     &           TIME(j1,numrow),slow(iu,INEXTS),h2,hs2i,ihit,irev)
+C
+C---------- 2d transmission from side
+            call trntim(TIME(j,ilastt),TIME(j,numrow),TIME(j1,ilastt),
+     &           TIME(j1,numrow),slow(iu,INEXTS),h2,hs2i,ihit,irev)
+            isave = 0
+            call reftim(time(j,numrow),time(j1,numrow),
+     &           slow(iu,IREFS),slow(iu,INEXTS),H,isave)
+C
+C---------- if a refraction occurs sweep to the end of this row
+            if (isave .ne. 0) then
+               ifirst = 1
+               do k=j+1,iright-1
+                  k1 = k+1
+                  IU = MIN(k,nx1)
+                  call reftim(time(k,numrow),time(k1,numrow),
+     &                 slow(iu,IREFS),slow(iu,INEXTS),H,ihit)
+               enddo
+            endif
+         enddo
+      enddo
+C
+C---- if we are reversing the calculation assign minimum time hit flag
+      if (irev .ne. 0) ifirst = max(ihit,ifirst)
+      RETURN
+      END
+c
+c======================================================================
+c
+      subroutine inttrt(h,time,slow,mxx,nx,nz,srcx,srcz,
+     &     xrec,zrec,times,nrec)
+C
+C     inttim calculates times for requested x,z receiver positions
+C     using bilinear interpolation of the cartesian travel-time field
+C
+      implicit none
+      integer nrec,mxx,nx,nz,i,ix,iz,iz1,ix1,ixs,izs
+      real time(mxx,nz),slow(mxx,nz),h,hi,za,zb,onemfx,fx,fz,sro
+      real xrec(1:*),zrec(1:*),times(1:*),srcx,srcz
+C
+C---- reduce some divisions
+      hi = 1.0/h
+C
+C---- calculate source position
+      ixs = min(1 + int(srcx*hi),nx-1)
+      izs = min(1 + int(srcz*hi),nz-1)
+C
+C---- loop through number of receivers
+      do i = 1,nrec
+C
+C------- calculate index position on cartesian grid
+         ix = min(1 + int(xrec(i)*hi),nx-1)
+         iz = min(1 + int(zrec(i)*hi),nz-1)
+C
+C------- do bilinear interpolation
+         fx = (xrec(i)-float(ix-1)*h)*hi
+         fz = (zrec(i)-float(iz-1)*h)*hi
+         ix1 = ix+1
+         iz1 = iz+1
+         onemfx = 1.0-fx
+         za = fx*time(ix1,iz) + time(ix,iz)*onemfx
+         zb = fx*time(ix1,iz1) + time(ix,iz1)*onemfx
+         times(i) = fz*zb + za*(1.0-fz)
+C
+C------- check for receiver in source cell and check for minimum time
+         if (ixs .eq. ix .and. izs .eq. iz) then
+            sro = sqrt((xrec(i)-srcx)**2 + (zrec(i)-srcz)**2)
+C
+C---------- take min of interpolated time and direct arrival time
+            times(i) = min(times(i),sro*slow(ixs,izs))
+         endif
+      enddo
+      return
+      end
+c
+c======================================================================
+c
+      subroutine angrgn(xmin,xmax,zmin,zmax,dx,dz,xsrc,zsrc,angstr,
+     &     angend,dr,dp,nr,np,r,p,cang,sang)
+C
+C     angrgn determines the minimum and maximum angles required to fit
+C     the circular travel-time grid to the rectangular velocity system
+C     and resonable values of polar variable incremements
+C
+      implicit none
+      integer nr,np,i
+      double precision angstr,angend,dr,dp,dxm,dzm,c,c2,bx,bz,ax,az,
+     &     r(0:*),p(1:*),cang(1:*),sang(1:*)
+      real xmin,xmax,zmin,zmax,dx,dz,xsrc,zsrc
+C
+C---- check boundaries
+      if (zsrc .eq. zmin) then
+         if (xsrc .lt. xmax) then
+            angend = 0.D0
+            if (xsrc .eq. xmin) then
+               angstr = -1.5707963267948966D0
+            else
+               angstr = -3.1415926535897931D0
+            endif
+         else
+            angend = -1.5707963267948966D0
+            angstr = -3.1415926535897931D0
+         endif
+      else if (zsrc .eq. zmax) then
+         if (xsrc .lt. xmax) then
+            angstr =0.D0
+            if (xsrc .eq. xmin) then
+               angend = 1.5707963267949001D0
+            else
+               angend = 3.1415926535897931D0
+            endif
+         else
+            angstr = 1.5707963267948966D0
+            angend = 3.1415926535897931D0
+         endif
+      else if (xsrc .eq. xmin) then
+         angstr = -1.5707963267949001D0
+         angend = 1.5707963267949001D0
+      else if (xsrc .eq. xmax) then
+         angstr = 1.5707963267948966D0
+         angend = 4.7123889803846932D0
+      else
+C
+C------- source within model sweep over 2 pi
+         angstr = 0.0D0
+         angend = 6.2831853071795862D0
+c         print *,' Error: source is not located on the grid boundary.'
+c         print *,' xmin ',xmin,' xmax ',xmax,' zmin ',zmin,' zmax ',zmax
+c         read(*,*)
+c         stop
+      endif
+      dxm = max(xmax - xsrc, xsrc - xmin)
+      dzm = max(zmax - zsrc, zsrc - zmin)
+      c2 = dxm*dxm + dzm*dzm
+      c = sqrt(c2)
+      bx = sqrt(c2 - dx*dx)
+      bz = sqrt(c2 - dz*dx)
+      ax = abs(acos((bx*bx+c2-dx*dx)/(2.D0*bx*c)))
+      az = abs(acos((bz*bz+c2-dz*dz)/(2.D0*bz*c)))
+C
+C---- calculate preliminary delta theta
+      dp = 0.5D0*min(ax,az)
+C
+C---- find delta theta that is <= dp that fits between angstr and angend
+      bx = abs(angend-angstr)
+      np = 1+ INT(bx/dp)
+      dp = bx/dble(np-1)
+C      print *,'np ',np
+C
+C---- make sure the start is exact
+      p(1) = angstr
+      sang(1) = sin(angstr)
+      cang(1) = cos(angstr)
+      do i=2,np-1
+         p(i) = p(i-1) + dp
+         sang(I) = sin(p(i))
+         cang(i) = cos(p(i))
+      enddo
+C
+C---- make sure the end is exact
+      p(np) = angend
+      sang(np) = sin(p(np))
+      cang(np) = cos(p(np))
+C
+C---- find radial increment and number of rings
+      dr = 0.5D0*min(dx,dz)
+      c = c + 1.5D0*dr
+      nr = 1 + int(c/dr)
+C      print *,'nr ',nr
+      dr = c/dble(nr-1)
+      r(0) = 0.D0
+      r(1) = dr
+      do i=2,nr+1
+         r(i) = r(i-1) + dr
+      enddo
+      end
+c
+c======================================================================
+c
+      subroutine crnswp(iostr,ioend,time,mxp,mxr,j,j1,s,
+     &     idir,r24,sfac,dr2,rdr4,facnd,drrdpi,tm1cof,tm2cof,tm3cof,dd)
+C
+C     CRNSWP calculates times to a corner in an outward sweep over a radius
+C     ring.
+C
+      IMPLICIT NONE
+      INTEGER iostr,ioend,MXP,MXR,J,I,J1,I1,idir
+      DOUBLE PRECISION TIME(MXP,MXR),r24,sfac,dr2,rdr4,facnd,
+     &     drrdpi,tm1cof,tm2cof,tm3cof,tmcorn,s(1:*),tdiff,dd,tmp
+      EXTERNAL tmcorn
+C
+C
+C------- calculate times within segment
+      DO I= iostr,ioend,idir
+         I1 = I + idir
+         tdiff = time(i1,j1) - time(i,j1)
+C
+C------- check illumination condition (from Podvin and Lecomte, 1991 JGI)
+         if (tdiff .ge. 0.d0 .and. tdiff .le. s(i)*dd) then
+            tmp = tmcorn(time(i,j1),time(i1,j1),time(i,j),s(i),r24,
+     &           sfac,dr2,rdr4,facnd,drrdpi,tm1cof,tm2cof,tm3cof)
+            TIME(I1,J) = min(tmp,time(i1,j))
+         endif
+      enddo
+      return
+      end
+c
+c======================================================================
+c
+      SUBROUTINE crntim(time1,time2,time3,time4,slocel,slo1,slo2,
+     &     ifrstc,ifrstr,h,h2,HTSQR2,HS2I)
+C-----------------------------------------------------------------
+C     CRNTIM calculates travel times for a corner and returns the
+C      minimum travel times in time4.
+C
+C         slo2
+C     4 +      + 3
+C
+C slo1   slocel
+C
+C     2 +      + 1 times 1,2,3 are known and 4 is returned
+C
+C-----------------------------------------------------------------
+      IMPLICIT NONE
+      REAL time1,time2,time3,time4,slocel,slo1,slo2,h,h2,HTSQR2,HS2I
+      INTEGER ifrstc,ifrstr,ihit
+C
+C---- 2d diffraction
+      call diftim(TIME1,TIME4,slocel,HTSQR2,ihit)
+C
+C---- 2d transmission
+      call trntim(TIME1,TIME2,TIME3,TIME4,slocel,h2,hs2i,ihit,0)
+      call trntim(TIME1,TIME3,TIME2,TIME4,slocel,h2,hs2i,ihit,0)
+C
+C---- 2d refraction
+      call reftim(time2,time4,slocel,slo1,H,ifrstr)
+      call reftim(time3,time4,slocel,slo2,H,ifrstc)
+      RETURN
+      END
+c
+c======================================================================
+c
+      SUBROUTINE defcon(dr,dp,dr2,dr3,dp2,drdp,dp2dr2,dp2i,dridpi,
+     &     drdp22)
+      IMPLICIT NONE
+      DOUBLE PRECISION dr,dp,dr2,dp2,dp2dr2,dp2i,dridpi,drdp22,dr3,
+     &     drdp
+C
+c---- things calculated before starting grid calculations
+c
+      dr2 = dr*dr
+      dr3 = dr2*dr
+      dp2 = dp*dp
+      dp2dr2 = -dp2/dr2
+      dp2i = 1.0D0/dp2
+      drdp = dr*dp
+      dridpi = 1.0D0/drdp
+      drdp22 = dr2*dp2
+      RETURN
+      END
+c
+c======================================================================
+c
+      SUBROUTINE difswp(iostr,ioend,TIME,MXP,MXR,J,J1,dd,s,idir)
+C
+C     DIFSWP calculates the diagonal diffractions across the cells
+C     of a radius ring
+C
+      IMPLICIT NONE
+      INTEGER iostr,ioend,J,idir,I,I1,J1,MXP,MXR
+      DOUBLE PRECISION TIME(MXP,MXR),dd,s(1:*),tmp
+C
+C---- calculate times within segment
+      DO I= iostr,ioend,idir
+         I1 = I + IDIR
+         tmp = dd*s(i) + TIME(I,J1)
+C
+C------- if time is earlier, save it and set flag
+         TIME(I1,J) = min(tmp,TIME(I1,J))
+      ENDDO
+      RETURN
+      END
+c
+c======================================================================
+c
+      subroutine DIFTIM(TIMEK,TIMEC,SLOW,HTSQR2,IFIRST)
+C
+C     DIFTIM calculates the time of a diffraction across a cell
+C
+      IMPLICIT NONE
+      INTEGER IFIRST
+      REAL TIMEK,TIMEC,SLOW,TMP,HTSQR2
+      TMP = TIMEK + HTSQR2*SLOW
+      IF (TMP .LT. TIMEC) THEN
+         IFIRST = 1
+         TIMEC = TMP
+      ENDIF
+      RETURN
+      END
+c
+c======================================================================
+c
+      subroutine fndcmn(time,mxx,nz,nc,itop,ibot,nmin,minstr,mnlend,
+     &     mnuend,tmmin,indexm)
+      implicit none
+      integer mxx,nz,itop,ibot,nmin,minstr(1:*),mnlend(1:*),
+     &     mnuend(1:*),i,nc,lookmx,indexm(1:*)
+      real time(mxx,nz),tdif,tdifl,sdif,sdifl,tmmin(1:*)
+      do i = itop, ibot -1
+         tdif = time(nc,i+1)-time(nc,i)
+         sdif = sign(1.0,tdif)
+         if(i .eq. itop) then
+            nmin = 1
+            if (tdif .ge. 0.0) then
+C
+C------------- we are starting at a minimum
+               minstr(nmin) = i
+               tmmin(nmin) = time(nc,i)
+               mnlend(nmin) = i+1
+C
+C------------- flag other end no yet found
+               mnuend(nmin) = -10
+               lookmx = 1
+            else
+C
+C------------- we are starting at a maximum
+               mnlend(nmin) = i+1
+               minstr(nmin) = -10
+               mnuend(nmin) = -10
+               lookmx = 0
+            endif
+         else
+C
+C---------- look for sign change indicating a min or max
+            if (sdif .ne. sdifl) then
+               if (sdif .gt. 0.0) then
+C
+C---------------- its a minimum
+                  if (lookmx .ne. 0) print *,'trouble, looking max',
+     &                 ' found a minimum instead'
+                  minstr(nmin) = i
+                  tmmin(nmin) = time(nc,i)
+                  lookmx = 1
+               else
+C
+C---------------- its a maximum
+                  if (lookmx .eq. 0) print *,'trouble, looking min',
+     &                 ' found a maximum instead'
+                  mnuend(nmin) = i-1
+                  nmin = nmin+1
+                  mnlend(nmin) = i+1
+                  minstr(nmin) = -10
+                  mnuend(nmin) = -10
+                  lookmx = 0
+               endif
+            endif
+         endif
+         tdifl = tdif
+         sdifl = sdif
+      enddo
+C
+C---- cleanup loose ends
+      if (minstr(nmin) .eq. -10) then
+         minstr(nmin) = ibot
+         mnuend(nmin) = ibot-1
+         tmmin(nmin) = time(nc,ibot)
+      else if(mnuend(nmin) .eq. -10) then
+         mnuend(nmin) = ibot-1
+      endif
+C
+C---- sort by time and return sort index
+      call INDEXX(nmin,tmmin,indexm)
+      return
+      end
+c
+c======================================================================
+c
+      subroutine fndrmn(time,mxx,nz,nc,ileft,iright,nmin,minstr,mnlend,
+     &     mnuend,tmmin,indexm)
+      implicit none
+      integer mxx,nz,ileft,iright,nmin,minstr(1:*),mnlend(1:*),
+     &     mnuend(1:*),i,nc,lookmx,indexm(1:*)
+      real time(mxx,nz),tdif,tdifl,sdif,sdifl,tmmin(1:*)
+      do i = ileft, iright -1
+         tdif = time(i+1,nc)-time(i,nc)
+         sdif = sign(1.0,tdif)
+         if(i .eq. ileft) then
+            nmin = 1
+            if (tdif .ge. 0.0) then
+C
+C------------- we are starting at a minimum
+               minstr(nmin) = i
+               tmmin(nmin) = time(i,nc)
+               mnlend(nmin) = i+1
+C
+C------------- flag other end no yet found
+               mnuend(nmin) = -10
+               lookmx = 1
+            else
+C
+C------------- we are starting at a maximum
+               mnlend(nmin) = i+1
+               minstr(nmin) = -10
+               mnuend(nmin) = -10
+               lookmx = 0
+            endif
+         else
+C
+C---------- look for sign change indicating a min or max
+            if (sdif .ne. sdifl) then
+               if (sdif .gt. 0.0) then
+C
+C---------------- its a minimum
+                  if (lookmx .ne. 0) print *,'trouble, looking max',
+     &                 ' found a minimum instead'
+                  minstr(nmin) = i
+                  tmmin(nmin) = time(i,nc)
+                  lookmx = 1
+               else
+C
+C---------------- its a maximum
+                  if (lookmx .eq. 0) print *,'trouble, looking min',
+     &                 ' found a maximum instead'
+                  mnuend(nmin) = i-1
+                  nmin = nmin+1
+                  mnlend(nmin) = i+1
+                  minstr(nmin) = -10
+                  mnuend(nmin) = -10
+                  lookmx = 0
+               endif
+            endif
+         endif
+         tdifl = tdif
+         sdifl = sdif
+      enddo
+C
+C---- cleanup loose ends
+      if (minstr(nmin) .eq. -10) then
+         minstr(nmin) = iright
+         mnuend(nmin) = iright-1
+         tmmin(nmin) = time(iright,nc)
+      else if(mnuend(nmin) .eq. -10) then
+         mnuend(nmin) = iright-1
+      endif
+C
+C---- sort by time and return sort index
+      call INDEXX(nmin,tmmin,indexm)
+      return
+      end
+c
+c======================================================================
+c
+      subroutine forwrd(r,dr,dp,dr2,dr3,dp2,dp2dr2,dp2i,dridpi,
+     &        drdp22,drdp,cosp,sring,time,mxp,mxr,j,j1,rftest,np)
+C
+C     forwrd calculates outward times for the current ring using
+C     all the appropriate time stencils
+C
+      implicit none
+      integer mxp,mxr,j,j1,rftest,np
+      double precision r,dr,dp,dr2,dr3,dp2,dp2dr2,dp2i,dridpi,drdp22,
+     &     sring(0:mxp,2),time(mxp,mxr),drpr,drpr2,drpr2i,rdr4,r24,
+     &     drrdpi,tm1cof,tm2cof,tm3cof,facnd,sfac,dd,drdp,cosp
+C
+C---- pre-calculate radius dependent parameters
+      call RDFCON(r,dr,dp,dr2,dp2,dp2dr2,dp2i,dridpi,drdp22,drpr,
+     &     drpr2,drpr2i,rdr4,r24,drrdpi,tm1cof,tm2cof,tm3cof,facnd,
+     &     sfac,dd,drdp,cosp)
+C
+C---- CALCULATE RADIAL TRAVEL-TIMES
+      rftest=0
+      CALL RADTIM(np,TIME,MXP,MXR,J,J1,dr,sring(0,1))
+C
+C---- CALCULATE DIFFRACTION TRAVEL-TIMES
+C---- sweep to max angle
+      call difswp(1,np-1,TIME,MXP,MXR,J,J1,dd,sring(1,1),1)
+C---- sweep to min angle
+      call difswp(np,2,TIME,MXP,MXR,J,J1,dd,sring(0,1),-1)
+C
+C---- calculate corner times
+C---- sweep to max angle
+      call crnswp(1,np-1,TIME,MXP,MXR,J,J1,sring(1,1),1,
+     &     r24,sfac,dr2,rdr4,facnd,drrdpi,tm1cof,tm2cof,tm3cof,dd)
+C---- sweep to min angle
+      call crnswp(np,2,TIME,MXP,MXR,J,J1,sring(0,1),-1,
+     &     r24,sfac,dr2,rdr4,facnd,drrdpi,tm1cof,tm2cof,tm3cof,dd)
+C
+C---- calculate refracted times
+C---- sweep to maximum angle
+      rftest = 0
+      CALL REFSWP(1,np-1,TIME,MXP,MXR,J,drdp,sring(1,1),
+     &     sring(1,2),1,rftest)
+C---- sweep to minimum angle
+      CALL REFSWP(np,2,TIME,MXP,MXR,J,drdp,sring(0,1),
+     &     sring(0,2),-1,rftest)
+      return
+      end
+c
+c======================================================================
+c
+      SUBROUTINE INDEXX(N,ARRIN,INDX)
+C
+C     HEAPSORT indexing routine from numerical recipes
+C
+      implicit none
+      integer n,indx(1:*),I,J,L,IR,INDXT
+      real arrin(1:*),Q
+      DO  J=1,N
+        INDX(J)=J
+      enddo
+      if(n.lt.2) return
+      L=N/2+1
+      IR=N
+      do while (1 .ne. 0)
+         IF(L.GT.1)THEN
+            L=L-1
+            INDXT=INDX(L)
+            Q=ARRIN(INDXT)
+         ELSE
+            INDXT=INDX(IR)
+            Q=ARRIN(INDXT)
+            INDX(IR)=INDX(1)
+            IR=IR-1
+            IF(IR.EQ.1)THEN
+               INDX(1)=INDXT
+               RETURN
+            ENDIF
+         ENDIF
+         I=L
+         J=L+L
+         do while (J.LE.IR)
+            IF(J.LT.IR)THEN
+               IF(ARRIN(INDX(J)).LT.ARRIN(INDX(J+1)))J=J+1
+            ENDIF
+            IF(Q.LT.ARRIN(INDX(J)))THEN
+               INDX(I)=INDX(J)
+               I=J
+               J=J+J
+            ELSE
+               J=IR+1
+            ENDIF
+         enddo
+         INDX(I)=INDXT
+      enddo
+      END
+c
+c======================================================================
+c
+      subroutine intxzt(dr,dp,r,p,time,mxp,np,nr,xsrc,zsrc,timexz,mxx,
+     &     nx,nz,dx,dz,xmin,xmax,zmin,zmax,iangr)
+C
+C     inttim calculates times for requested x,z receiver positions
+C     using bilinear interpolation of the polar travel-time field
+C
+      implicit none
+      integer mxp,nr,i,ir,ip,ip1,ir1,mxx,nz,np,j,ixs,ixe,
+     &     izs,ize,nx,iangr
+      double precision dr,dp,p(1:*),time(mxp,nr),rreq,preq,fp,fr,
+     &     za,zb,x,z,r(0:*),onemfp,t1,t2
+      real xsrc,zsrc,timexz(mxx,nz),dx,dz,xmin,xmax,zmin,zmax,xrec,
+     &     zrec
+C
+C---- compute portion of cartesian grid that needs times from the polar grid
+      ixs = max(1,int(xmin/dx))
+      ixe = min(nx,1+nint(xmax/dx))
+      izs = max(1,int(zmin/dz))
+      ize = min(nz,1+nint(zmax/dz))
+C      print *,'ixs,ixe,izs,ize'
+C      print *,ixs,ixe,izs,ize
+C      print *,'nz,zmax,dz,nint(zmax/dz)'
+C      print *,nz,zmax,dz,nint(zmax/dz)
+C
+C---- loop through cartesian subgrid
+      do i = izs, ize
+         zrec = float(i-1)*dz
+         do j = ixs,ixe
+            xrec = float(j-1)*dx
+            x = xrec - xsrc
+C
+C---------- make z negative down
+            z = zsrc - zrec
+C
+C---------- calculate polar coordinates
+            rreq = sqrt(x*x + z*z)
+            if (z .ne. 0.0 .or. x .ne. 0.0) then
+               preq = atan2(z,x)
+            else
+               preq = p(1)
+            endif
+C
+C---------- have to map the angle depending on the signs of the angle range
+C---------- or if source position inside model requires 360 degree sweep
+            if (p(1) .gt. 0.D0 .or. iangr .eq. 0) then
+               if (preq .lt. 0.D0) preq = 6.2831853071795862D0+preq
+            else if(p(1) .lt. -3.D0 .and.
+     &              preq .eq. 3.1415926535897931D0) then
+               preq = -3.1415926535897931D0
+            endif
+C
+C---------- define angle within range if source is at polar origin
+            if (rreq .eq. 0.0) preq = p(1)
+            if (rreq .ge. 0.0 .and. rreq .le. r(nr) .and.
+     &           preq .ge. p(1) .and. preq .le. p(np)) then
+C
+C------------- calculate index position on polar grid
+               ir = int(rreq/dr)
+               ip = 1 + int((preq-p(1))/dp)
+               if (ip .eq. np) ip = ip - 1
+C
+C------------- do bilinear interpolation
+               fp = (preq-p(ip))/dp
+               fr = (rreq-r(ir))/dr
+               ip1 = ip+1
+               ir1 = ir+1
+               onemfp = 1.D0-fp
+C
+C------------- if time needed is not source point compute interpolation
+               if (ir .ne. 0) then
+                  za = fp*time(ip1,ir) + time(ip,ir)*onemfp
+               else
+C
+C---------------- polar source time is zero
+                  za = 0.d0
+               endif
+               zb = fp*time(ip1,ir1) + time(ip,ir1)*onemfp
+               timexz(j,i) = fr*zb + za*(1.D0-fr)
+            endif
+         enddo
+      enddo
+      return
+      end
+c
+c======================================================================
+c
+      SUBROUTINE radtim(np,TIME,MXP,MXR,J,J1,dr,s)
+C
+C     RADTIM calculates the simple radial times from one radius ring
+C     to the next
+C
+      IMPLICIT NONE
+      INTEGER np,MXP,MXR,J,I,J1
+      DOUBLE PRECISION TIME(MXP,MXR),dr,s(0:*),tmp
+
+C
+C---- calculate times within ring
+      DO I=1,np
+         tmp = dr*min(s(i-1),s(i)) + TIME(I,J1)
+         TIME(I,J) = min(tmp,TIME(i,j))
+      enddo
+      RETURN
+      END
+c
+c======================================================================
+c
+      subroutine raypth(time,slow,mxx,nx,nz,h,xis,zis,xir,zir,xpos,zpos,
+     &     dkern,mxa,nrv,nr)
+      implicit none
+      integer mxx,mxa,nx,nz,nr,nrv(1:*),i,j,isx,isz,nk,it,ix,ix1,
+     &     ixm1,iz,iz1,izm1,ixn,ixl,izn,izl,nx1,nz1,k,m,xpos(mxa,nr),
+     &     zpos(mxa,nr),nk1
+      real time(mxx,nz),slow(mxx,nz),h,xis,zis,xir(1:*),zir(1:*),
+     &     dkern(mxa,nr),HI,xi,zi,rinc,
+     &     lwzd,upzd1,lwzd1,f,dtdz,dtdx,lfxd,lfxd1,rtxd,rtxd1,xn,zn,fnx,
+     &     fnz,xinc,ang,cang,sang,xdif,zdif,angl,angc,xc,xs,zc,zs,dif,
+     &     upzd,zinc,xisw,zisw
+C
+C---- setup source cell index (there is one less cell than time in each dim.)
+      hi = 1.0/H
+      fnx = float(nx)
+      fnz = float(nz)
+      nx1 = nx-1
+      nz1 = nz-1
+      xisw = xis*hi
+      zisw = zis*hi
+      isx = max(1,min(1+int(xisw),nx1))
+      isz = max(1,min(1+int(zisw),nz1))
+      xisw = xisw+1.
+      zisw = zisw+1.
+C
+C---- loop through number of receiver positions
+      do i=1,nr
+         nk=1
+         rinc = 0.
+         it = 1
+         xi = 1.+xir(i)*hi
+         zi = 1.+zir(i)*hi
+         xpos(1,1) = 0.
+         zpos(1,1) = 0.
+C
+C------- calculate path from receiver to source position until the path
+C------- intersects the source cell
+         do while (it .ne. 0)
+C
+C---------- find cell indices about current path position
+            ix = min(int(xi),nx)
+            ix1 = min(ix+1,nx)
+            ixm1 = max(1,ix-1)
+            iz = min(int(zi),nz)
+            iz1 = min(iz+1,nz)
+            izm1 = max(1,iz-1)
+C
+C---------- compute quantities for z component of the gradient
+            upzd = time(ix,izm1)-time(ix,iz)
+            lwzd = time(ix,iz)-time(ix,iz1)
+            upzd1 = time(ix1,izm1)-time(ix1,iz)
+            lwzd1 = time(ix1,iz)-time(ix1,iz1)
+C
+C---------- handle grid edges gracefully
+            if (izm1 .eq. iz) then
+               upzd = sign(1.e-6,lwzd)
+               upzd1 = sign(1.e-6,lwzd1)
+            else if(iz .eq. iz1) then
+               lwzd = sign(1.e-6,upzd)
+               lwzd1 = sign(1.e-6,upzd1)
+            endif
+C
+C---------- linear interpolation relative to x position
+            f = xi - float(ix)
+            upzd = f * upzd1 + (1.0-f)* upzd
+            lwzd = f * lwzd1 + (1.0-f)* lwzd
+C
+C---------- calculate z time gradient, checking for time discontinuity
+            if (sign(1.0,upzd) .ne. sign(1.0,lwzd)) then
+               dtdz = 0.
+            else
+               dtdz = 0.5*(upzd+lwzd)
+            endif
+C
+C---------- x time gradient
+            lfxd = time(ixm1,iz)-time(ix,iz)
+            lfxd1 = time(ixm1,iz1)-time(ix,iz1)
+            rtxd = time(ix,iz)-time(ix1,iz)
+            rtxd1 = time(ix,iz1)-time(ix1,iz1)
+            if (ixm1 .eq. ix) then
+               lfxd = sign(1.e-6,rtxd)
+               lfxd1 = sign(1.e-6,rtxd1)
+            else if(ix .eq. ix1) then
+               rtxd = sign(1.e-6,lfxd)
+               rtxd1 = sign(1.e-6,lfxd1)
+            endif
+C
+C---------- linear interpolation
+            f = zi - float(iz)
+            lfxd = f * lfxd1 + (1.0-f) * lfxd
+            rtxd = f * rtxd1 + (1.0-f) * rtxd
+C
+C---------- calculate x time gradient, checking for time discontinuity
+            if (sign(1.0,lfxd) .ne. sign(1.0,rtxd)) then
+               dtdx = 0.
+            else
+               dtdx = 0.5*(lfxd+rtxd)
+            endif
+C
+C---------- calculate gradient direction
+            ang=atan2(dtdz,dtdx)
+            cang = cos(ang)
+            sang = sin(ang)
+C
+C---------- calculate position of projected point
+            xn = max(1.,min(xi+cang,fnx))
+            zn = max(1.,min(zi+sang,fnz))
+C
+C---------- calculate index location values
+            ixn = int(xn)
+            ixl = int(xi)
+            izn = int(zn)
+            izl = int(zi)
+C
+C---------- if we have left the previous cell calculate its path length
+            if (ixn .ne. ixl .or. izn .ne. izl) then
+               zdif = zn-zi
+               xdif = xn-xi
+               if (xi .eq. float(ixl) .and. xdif .lt. 0.0) ixl = ixl-1
+               if (zi .eq. float(izl) .and. zdif .lt. 0.0) izl = izl-1
+C
+C------------- find intersection with the cell wall by looking at angles of
+C------------- the ray and the angle to the corner of the sub-cell the ray
+C------------- departs through
+               angl = atan2(abs(zdif),abs(xdif))
+               if (cang .lt. 0.0) then
+                  xs = abs(xi - float(ixl))
+               else
+                  xs = abs(1.+float(ixl)-xi)
+               endif
+               if (sang .lt. 0.0) then
+                  zs = abs(zi - float(izl))
+               else
+                  zs = abs(1.+float(izl)-zi)
+               endif
+               angc = atan2(zs,xs)
+               if (angl .gt. angc) then
+                  zc = zs
+                  if (xdif .ne. 0.0) then
+                     xc = zc/tan(angl)
+                  else
+                     xc = 0.
+                  endif
+               else
+                  xc = xs
+                  zc = xc*tan(angl)
+               endif
+C
+C------------- check for vertical refractions and use index of fast side
+               j = max(1,min(ixl,nx1))
+               k = min(ixl,nx1)
+               m = min(izl,nz1)
+               if (xn .ne. xi) then
+                  xpos(nk,i) = j
+               else
+                  if (slow(k,m) .lt. slow(max(1,ixl-1),m)) then
+                     xpos(nk,i) = j
+                  else
+                     xpos(nk,i) = max(1,ixl-1)
+                  endif
+               endif
+C
+C------------- check for horizontal refractions and use index of fast side
+               j = max(1,min(izl,nz1))
+               k = min(izl,nz1)
+               m = min(ixl,nx1)
+               if (zn .ne. zi) then
+                  zpos(nk,i) = j
+               else
+                  if (slow(m,k) .lt. slow(m,max(1,izl-1))) then
+                     zpos(nk,i) = j
+                  else
+                     zpos(nk,i) = max(1,izl-1)
+                  endif
+               endif
+               dkern(nk,i) = rinc + h*sqrt(xc*xc+zc*zc)
+C
+C------------- check for and eliminate duplicates
+               nk1 = nk -1
+               if (nk1 .ne. 0 .and. xpos(nk1,i) .eq. xpos(nk,i) .and.
+     &              zpos(nk1,i) .eq. zpos(nk,i)) then
+                  dkern(nk1,i) = dkern(nk1,i) + dkern(nk,i)
+                  dkern(nk,i) = 0.0
+               endif
+               rinc = 0.0
+C
+C------------- require nonzero contribution
+               if (dkern(nk,i) .gt. 0.0) nk = nk+1
+C
+C------------- if both x and z indices change we probably hit the corner of
+C------------- second cell and need to calculate its path length and store it
+C------------- before proceeding
+               if (ixn .ne. ixl .and. izn .ne. izl .and.
+     &              angl .ne. angc) then
+C
+C---------------- move to boundary and see which of x or z advances
+                  if (angl .gt. angc) then
+                     xc = abs(xs-xc)
+                     zc = xc*tan(angl)
+                     if (sang .gt. 0.0) then
+                        izl = min(izl+1,nz1)
+                     else
+                        izl = max(1,izl-1)
+                     endif
+                     xs = xi + xs*sign(1.0,xdif)
+                     zs = zi + (zs + zc)*sign(1.0,zdif)
+                  else
+                     zc = abs(zs-zc)
+                     xc = zc/tan(angl)
+                     if (cang .gt. 0.0) then
+                        ixl = min(ixl+1,nx1)
+                     else
+                        ixl = max(1,ixl-1)
+                     endif
+                     zs = zi + zs*sign(1.0,zdif)
+                     xs = xi + (xs + xc)*sign(1.0,xdif)
+                  endif
+C
+C---------------- don't need to check for refraction because the propagation
+C---------------- direction must be oblique to the coordinate axes by
+C---------------- definition to be within this if section
+                  xpos(nk,i) = max(1,min(ixl,nx1))
+                  zpos(nk,i) = max(1,min(izl,nz1))
+                  dkern(nk,i) = h*sqrt(xc*xc+zc*zc)
+C
+C---------------- check for and eliminate duplicates
+                  nk1 = nk -1
+                  if (nk1 .ne. 0 .and. xpos(nk1,i) .eq. xpos(nk,i) .and.
+     &                 zpos(nk1,i) .eq. zpos(nk,i)) then
+                     dkern(nk1,i) = dkern(nk1,i) + dkern(nk,i)
+                     dkern(nk,i) = 0.0
+                  endif
+                  if (dkern(nk,i) .gt. 0.0) nk = nk+1
+               else
+C
+C---------------- update tail position
+                  xs = xi + xc*sign(1.0,xdif)
+                  zs = zi + zc*sign(1.0,zdif)
+               endif
+C
+C------------- store leftover length projecting into the next (unfinished) cell
+               xinc = abs(xn-xs)
+               zinc = abs(zn-zs)
+               rinc = rinc + h*sqrt(xinc*xinc+zinc*zinc)
+            else
+C
+C------------- still have not left current cell
+               xinc = abs(xn-xi)
+               zinc = abs(zn-zi)
+               rinc = rinc + h*sqrt(xinc*xinc+zinc*zinc)
+            endif
+C
+C---------- check if we have hit source cell
+            xs = xn-xisw
+            zs = zn-zisw
+            dif = sqrt(xs*xs+zs*zs)
+C
+C---------- if we are within h of the source position exit the receiver loop
+            if (dif .le. 1.0 .or. (xi .eq. xn .and. zi .eq. zn)) it = 0
+C            if (dif .le. 1.0) it = 0
+C
+C---------- next last position becomes current new position
+            xi = xn
+            zi = zn
+         enddo
+C
+C------- pickup final path incrment to source
+C         print *,' number of path segments =',nk,i,xis,zis
+         nk = max(1,nk-1)
+C
+C------- if source cell does not have a contribution yet add it to the list
+         if (xpos(nk,i) .ne. isx .or. zpos(nk,i) .ne. isz) then
+            nk = nk + 1
+            xpos(nk,i) = max(1,min(isx,nx1))
+            zpos(nk,i) = max(1,min(isz,nz1))
+            dkern(nk,i) = rinc + h*dif
+         else
+C
+C---------- the final segment is added to the source cell total
+            dkern(nk,i) = dkern(nk,i)+h*dif+rinc
+         endif
+         nrv(i) = nk
+      enddo
+      return
+      end
+c
+c======================================================================
+c
+      SUBROUTINE rdfcon(r,dr,dp,dr2,dp2,dp2dr2,dp2i,dridpi,drdp22,drpr,
+     &     drpr2,drpr2i,rdr4,r24,drrdpi,tm1cof,tm2cof,tm3cof,facnd,
+     &     sfac,dd,drdp,cosp)
+      IMPLICIT NONE
+      DOUBLE PRECISION r,dr,dr2,dp2,dp2dr2,dp2i,dridpi,drdp22,drpr,
+     &     drpr2,drpr2i,rdr,r24,ridrpr,drrdpi,tm1cof,tm2cof,tm3cof,
+     &     facnd,sfac,rdr4,r2,dd,drdp,cosp,dp
+C
+c---- things calculated at each radius ring
+c
+      drpr = dr + r
+      drdp = drpr*dp
+      drpr2 = drpr*drpr
+      drpr2i = -1.0D0/drpr2
+      rdr = dr*r
+      rdr4 = 4.0D0*rdr
+      r2 = r*r
+      r24 = 4.0D0*r2
+      ridrpr = 1.0D0/(r*drpr)
+      drrdpi = -ridrpr*dridpi
+      tm1cof = dp2i*(dp2dr2-ridrpr)
+      tm2cof = dp2i*(ridrpr+dp2dr2)
+      tm3cof = dp2i*(drpr2i-dp2dr2)
+      facnd = dp2/(drpr2i+dp2dr2)
+      sfac = drdp22 + 2.0D0*dr*dp2*r + dr2 + r2*dp2
+C
+C---- calculate diffraction distance across cell
+      dd = sqrt(dr2 + drpr2 - 2.0D0*drdp*r*cosp)
+      return
+      end
+c
+c======================================================================
+c
+      subroutine refswp(iostr,ioend,time,mxp,mxr,nrn,
+     &     drdp,s1,s2,idir,rftest)
+      implicit none
+C
+C     REFSWP calculates the edge refraction at the cell boundary along
+C     a sweep of a radius ring
+C
+      integer mxp,mxr,nrn,i,i1,idir,rftest,j,j1,iostr,ioend
+      DOUBLE PRECISION time(mxp,mxr),drdp,s1(1:*),s2(1:*),tmp
+C
+C---- loop through a ring segment
+      DO I = iostr, ioend,idir
+         I1 = I+idir
+         tmp = drdp*min(s1(i),s2(i))+TIME(I,nrn)
+C
+C------- check for lower time
+         if (tmp .lt. TIME(I1,nrn)) then
+            rftest = 1
+            TIME(I1,nrn) = tmp
+C
+C---------- time the rest of the ring (don't need the rest of the ring
+C---------- segments since we hit an absorbing boundary first)
+            do j = i1, ioend, idir
+               j1 = j + idir
+               time(j1,nrn) = min(drdp*min(s1(j),s2(j))+TIME(j,nrn),
+     &              TIME(j1,nrn))
+            enddo
+         ENDIF
+      enddo
+      return
+      end
+c
+c======================================================================
+c
+      SUBROUTINE REFTIM(TIMEK,TIMEC,SLOW1,SLOW2,H,IFIRST)
+C
+C     REFTIM calculates the refracted time along cell boundaries
+C
+      IMPLICIT NONE
+      INTEGER IFIRST
+      REAL TIMEK,TIMEC,SLOW1,SLOW2,H,TMP
+      tmp = TIMEK+MIN(SLOW1,SLOW2)*H
+      if (tmp .lt. TIMEC) then
+         if (slow1 .lt. slow2) ifirst = 1
+         TIMEC = tmp
+      endif
+      RETURN
+      END
+c
+c======================================================================
+c
+      subroutine setrng(xmin,xmax,zmin,zmax,xsrc,zsrc,bigslo,angstr,
+     &     angend,dx,dz,dr,dp,nr,np,r,p,cang,sang,sring,mxp,sloxz,
+     &     mxx,nx,nz,ir,init,iangr)
+C
+C     setrng determines the indices of the angle limits needed for each
+C     ring to cover its portion of the rectangular grid.
+C     (for now, however, just use the entire grid defined by nr,np,dr,dp
+C      and fill the parts outside the grid with large slownesses)
+C
+      implicit none
+      integer nr,np,mxp,mxx,nx,nz,i,j,nxp1,nzp1,ix,iz,k,j1,
+     &     ir,init,inc,m,i1,i2,iangr,nxm1, nzm1
+      double precision angstr,angend,dr,dp,r(0:*),p(1:*),cang(1:*),
+     &     sang(1:*),sring(0:mxp,2),bigslo,dxi,dzi,sum,sumlst,dzin
+      real xmin,xmax,zmin,zmax,xsrc,zsrc,dx,dz,sloxz(mxx,nz)
+      dxi = 1.0D0/dble(dx)
+      dzi = 1.0D0/dble(dz)
+      dzin = -dzi
+      nxp1 = nx+1
+      nzp1 = nz+1
+      nxm1 = nx-1
+      nzm1 = nz-1
+c      open(11,file='slow.out',status='unknown',form='unformatted')
+c      open(11,file='slow.out',status='unknown',form='unformatted')
+c      write(11) nr,np,angstr,angend,dr,dp,dxi,dzi
+c      write(11) (p(i),i=1,np)
+c      write(11) (r(i),i=1,nr)
+C
+C---- if called for the first time calculate two rings
+      if (init .ne. 0) then
+         inc = 1
+      else
+C
+C------- Use the result of the previous call to only calculate the new
+C------- outer ring by moving the old one inward
+         inc = 2
+         do i= 0,np
+            sring(i,1) = sring(i,2)
+         enddo
+      endif
+C
+C---- calculate needed slowness ring(s)
+      do i=inc,2
+         i1 = i - 1
+         i2 = i - 2
+C
+C------- pre-calculate the first radial edge
+         sumlst = 0.D0
+         do m=i2,i1
+            k = ir+m
+C
+C---------- calculate indices of x,z slowness cell the polar grid
+C---------- point lands on
+            ix = int((r(k)*cang(1) + xsrc)*dxi)+1
+            iz = int(r(k)*sang(1)*dzin + zsrc*dzi)+1
+C
+C---------- check if requested cell is within grid or within
+C---------- a cell width of the grid (let the grid slowness out a bit)
+            if (ix .gt. nxp1 .or. iz .gt. nzp1) then
+C
+C------------- make points outside, very slow
+               sumlst = sumlst + bigslo
+            else
+               sumlst = sumlst + sloxz(max(1,min(ix,nxm1)),
+     &              max(1,min(iz,nzm1)))
+            endif
+         enddo
+C
+C------- loop through angles
+         do j=0,np
+C
+C---------- make cells next to edges slow if not a 360 degree sweep
+            if (j .eq. 0 .or. j .eq. np .and. iangr .ne. 0) then
+               sring(j,i) = bigslo
+            else
+C
+C------------- calculate slowness for polar cell
+               j1 = j + 1
+C
+C------------- wrap angle around for 360 degree sweep
+               if (j1 .gt. np) j1 = 2
+C
+C------------- convert four corners to x and z
+               sum = 0.D0
+C
+C------------- loop through 2 next corners of polar cell
+               do m=i2,i1
+                  k = ir+m
+C
+C---------------- calculate indices of x,z slowness cell the polar grid
+C---------------- point lands on
+                  ix = int((r(k)*cang(j1) + xsrc)*dxi)+1
+                  iz = int(r(k)*sang(j1)*dzin + zsrc*dzi)+1
+C
+C---------------- check if requested cell is within grid or within
+C---------------- a cell width of the grid (let the grid slowness out a bit)
+                  if (ix .gt. nxp1 .or. iz .gt. nzp1) then
+C
+C------------------- make points outside, very slow
+                     sum = sum + bigslo
+                  else
+                     sum = sum + sloxz(max(1,min(ix,nxm1)),
+     &                                 max(1,min(iz,nzm1)))
+                  endif
+               enddo
+C
+C------------- calculate polar cell slowness from the average of the 4 corners
+               sring(j,i) = 0.25D0*(sum+sumlst)
+C
+C------------- store last radial edge value
+               sumlst = sum
+            endif
+         enddo
+c         write(11) (sring(j,i),j=0,np)
+      enddo
+      return
+      end
+c
+c======================================================================
+c
+      DOUBLE PRECISION FUNCTION tmcorn(tm1,tm2,tm3,s,r24,sfac,dr2,
+     &     rdr4,facnd,drrdpi,tm1cof,tm2cof,tm3cof)
+      IMPLICIT NONE
+      DOUBLE PRECISION tm1,tm2,tm3,s,r24,sfac,dr2,rdr4,facnd,drrdpi,
+     &     tm1cof,tm2cof,tm3cof,tm2s,tm3tm2,tm1tm2,tsqr,tsqra
+C
+c     Solution to (dt/dr)^2 + (dt/dp)^2 = s*s for the time of the far corner
+c     of finite difference cell in r and theta where,
+c
+c     dt/dr = (tm4+tm3 - tm1 -tm2)/(2dr)
+c     dt/dp = (tm2-tm1)/(2rdp) + (tm4-tm3)/(2(r+dr)dp)
+c
+C---- horner expansion solution
+c
+c---- things calculated at each cell in the routine
+      tmcorn = 1.D10
+      tm2s = tm2*tm2
+      tm3tm2 = tm3*tm2
+      tm1tm2 = tm1*tm2
+      tsqra = r24*(s*s*sfac - tm3*tm3 + 2.0D0*tm3tm2 - tm2s) +
+     &     dr2*(2.0D0*tm1tm2 - tm1*tm1 - tm2s) +
+     &     rdr4*(tm3tm2 + tm1tm2 - tm3*tm1 - tm2s)
+c      if (tsqra .lt. 0.D0) return
+      tsqr = sqrt(abs(tsqra))
+      tmcorn = facnd*(tsqr*drrdpi+tm2cof*tm2+tm1cof*tm1+tm3cof*tm3)
+      return
+      end
+c
+c======================================================================
+c
+      subroutine TRNTIM(TIMEM,TIMEN,TIMEB,TIMEC,SLOW,H2,HS2I,IFIRST,
+     &     IREV)
+C
+C     TRNTIM calculates the conditional transmission across a cell
+C
+      IMPLICIT NONE
+      INTEGER IFIRST,IREV
+      REAL TIMEM,TIMEN,TIMEB,TIMEC,SLOW,H2,HS2I,TMP,DIFF,DIFF2
+      DIFF = TIMEN - TIMEM
+      DIFF2 = TIMEB-TIMEN
+C
+C---- Podvin and Lecomte ilumination condition (with sign test added as 3rd)
+      IF (DIFF .LT. 0.0 .OR. DIFF .GT. HS2I*SLOW .OR.
+     &     TIMEB-TIMEM .LE. 0.0) RETURN
+c      IF (DIFF .LT. 0.0 .OR. DIFF .GT. HS2I*SLOW) RETURN
+c      IF (IREV .NE. 0) THEN
+C
+C------- Podvin and Lecomte stencil
+c         TMP = TIMEN + SQRT(H2*SLOW*SLOW - DIFF*DIFF)
+c      ELSE
+C
+C------- Vidale plane-wave stencil (more accurate going forward)
+      TMP = TIMEM + SQRT(2.D0*H2*SLOW*SLOW - DIFF2*DIFF2)
+c      ENDIF
+      IF (TMP .LT. TIMEC) THEN
+         IFIRST = 1
+         TIMEC = TMP
+      ENDIF
+      RETURN
+      END

--- a/shakermaker/ffsp/ffsp_wrapper.f90
+++ b/shakermaker/ffsp/ffsp_wrapper.f90
@@ -1,0 +1,408 @@
+!==============================================================================
+! ffsp_wrapper.f90
+! Wrapper to integrate FFSP with Python via f2py
+! 
+! This wrapper encapsulates main FFSP functionality allowing direct calls
+! from Python without file I/O overhead
+!==============================================================================
+
+subroutine ffsp_run_wrapper( &
+    ! Input: Fault parameters
+    id_sf_type_in, freq_min_in, freq_max_in, &
+    fault_length_in, fault_width_in, &
+    x_hypc_in, y_hypc_in, depth_hypc_in, &
+    xref_hypc_in, yref_hypc_in, &
+    magnitude_in, fc_main_1_in, fc_main_2_in, rv_avg_in, &
+    ratio_rise_in, &
+    strike_in, dip_in, rake_in, &
+    pdip_max_in, prake_max_in, &
+    nsubx_in, nsuby_in, &
+    nb_taper_TRBL_in, &
+    seeds_in, &
+    id_ran1_in, id_ran2_in, &
+    angle_north_to_x_in, &
+    is_moment_in, &
+    ! Input: Velocity model
+    nlayers_in, &
+    vp_in, vs_in, rho_in, thick_in, qa_in, qb_in, &
+    ! Output: Dimensions
+    n_realizations_out, npts_out, &
+    ! Output: Source parameters (all realizations)
+    x_out, y_out, z_out, &
+    slip_out, rupture_time_out, rise_time_out, peak_time_out, &
+    strike_out, dip_out, rake_out, &
+    ! Output: Statistics
+    ave_tr_out, ave_tp_out, ave_vr_out, err_spectra_out, pdf_out, &
+    ! Output: Spectral data dimensions
+    ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
+    ! Output: STF time domain
+    stf_time_out, stf_out, &
+    ! Output: Spectrum frequency domain
+    freq_spec_out, moment_rate_out, dcf_out, &
+    ! Output: Octave-averaged spectrum
+    freq_center_out, logmean_synth_out, logmean_dcf_out &
+)
+    
+    use sp_sub_f
+    use fdtim_2d
+    use time_freq
+    implicit NONE
+    
+    !--------------------------------------------------------------------------
+    ! Input parameters
+    !--------------------------------------------------------------------------
+    integer, intent(in) :: id_sf_type_in
+    real, intent(in) :: freq_min_in, freq_max_in
+    real, intent(in) :: fault_length_in, fault_width_in
+    real, intent(in) :: x_hypc_in, y_hypc_in, depth_hypc_in
+    real, intent(in) :: xref_hypc_in, yref_hypc_in
+    real, intent(in) :: magnitude_in, fc_main_1_in, fc_main_2_in, rv_avg_in
+    real, intent(in) :: ratio_rise_in
+    real, intent(in) :: strike_in, dip_in, rake_in
+    real, intent(in) :: pdip_max_in, prake_max_in
+    integer, intent(in) :: nsubx_in, nsuby_in
+    integer, dimension(4), intent(in) :: nb_taper_TRBL_in
+    integer, dimension(3), intent(in) :: seeds_in
+    integer, intent(in) :: id_ran1_in, id_ran2_in
+    real, intent(in) :: angle_north_to_x_in
+    integer, intent(in) :: is_moment_in
+    
+    ! Velocity model
+    integer, intent(in) :: nlayers_in
+    real, dimension(nlayers_in), intent(in) :: vp_in, vs_in, rho_in, thick_in, qa_in, qb_in
+    
+    !--------------------------------------------------------------------------
+    ! Output parameters - Source data
+    !--------------------------------------------------------------------------
+    integer, intent(out) :: n_realizations_out, npts_out
+    
+    ! Output arrays - f2py will calculate dimensions automatically
+    real, intent(out) :: x_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: y_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: z_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: slip_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: rupture_time_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: rise_time_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: peak_time_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: strike_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: dip_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: rake_out(nsubx_in*nsuby_in, id_ran2_in-id_ran1_in+1)
+    
+    ! Statistics per realization
+    real, intent(out) :: ave_tr_out(id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: ave_tp_out(id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: ave_vr_out(id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: err_spectra_out(id_ran2_in-id_ran1_in+1)
+    real, intent(out) :: pdf_out(id_ran2_in-id_ran1_in+1)
+    
+    !--------------------------------------------------------------------------
+    ! Output parameters - Spectral data (for best realization)
+    !--------------------------------------------------------------------------
+    integer, intent(out) :: ntime_spec_out, nphf_spec_out, lnpt_spec_out
+    
+    ! STF time domain - will be allocated based on ntime from time_freq module
+    real, intent(out) :: stf_time_out(131072)  ! Max size (will use only ntime_spec_out)
+    real, intent(out) :: stf_out(131072)
+    
+    ! Spectrum frequency domain
+    real, intent(out) :: freq_spec_out(65536)  ! Max size (will use only nphf_spec_out)
+    real, intent(out) :: moment_rate_out(65536)
+    real, intent(out) :: dcf_out(65536)
+    
+    ! Octave-averaged spectrum
+    real, intent(out) :: freq_center_out(17)  ! Max size (will use only lnpt_spec_out)
+    real, intent(out) :: logmean_synth_out(17)
+    real, intent(out) :: logmean_dcf_out(17)
+    
+    !--------------------------------------------------------------------------
+    ! Local variables
+    !--------------------------------------------------------------------------
+    integer :: idum1, idum2, idum3
+    integer :: idum1_master, idum2_master, idum3_master
+    integer :: nsource, i, j, k, i_real, best_idx
+    real :: drp, rdip, rstrike, cosx, sinx, str_ref, dip_ref, area_sub
+    real :: xij, yij, xs, ys, xps, yps, zps, factor, rakei, dipi
+    real :: ave_tr, ave_tp, ave_vr, err_spectra, pdf
+    
+    !--------------------------------------------------------------------------
+    ! 0. Clean up previous state (CRITICAL for repeated calls)
+    !--------------------------------------------------------------------------
+    ! Deallocate arrays from previous runs
+    if (allocated(slip)) deallocate(slip, rstm, rptm, pktm, rpvel, beta, amu, &
+                        taper, rtx, rtz, rake_prt, dip_prt, amz_prt, depth_source, lrtp)
+    if (allocated(freq)) deallocate(freq)
+
+    !--------------------------------------------------------------------------
+    ! 1. Assign parameters to sp_sub_f module variables
+    !--------------------------------------------------------------------------
+    id_sf_type = id_sf_type_in
+    flx = fault_length_in
+    fwy = fault_width_in
+    x_hypc = x_hypc_in
+    y_hypc = y_hypc_in
+    depth_hypc = depth_hypc_in
+    Moment_o = magnitude_in
+    fc_main_1 = fc_main_1_in
+    fc_main_2 = fc_main_2_in
+    nsubx = nsubx_in
+    nsuby = nsuby_in
+    
+    ! Calculate dimensions (for output)
+    n_realizations_out = id_ran2_in - id_ran1_in + 1
+    npts_out = nsubx * nsuby
+    
+    !--------------------------------------------------------------------------
+    ! 2. Setup velocity model
+    !--------------------------------------------------------------------------
+    layer = nlayers_in
+    
+    if (allocated(vvp)) deallocate(vvp, vvs, roh, thk, qp, qs)
+    allocate(vvp(layer+2), vvs(layer+2), roh(layer+2))
+    allocate(thk(layer+2), qp(layer+2), qs(layer+2))
+    
+    do i = 1, layer
+        vvp(i) = vp_in(i)
+        vvs(i) = vs_in(i)
+        roh(i) = rho_in(i)
+        thk(i) = thick_in(i)
+        qp(i) = qa_in(i)
+        qs(i) = qb_in(i)
+    enddo
+    
+    !--------------------------------------------------------------------------
+    ! 3. Convert Magnitude to Moment (if needed)
+    !--------------------------------------------------------------------------
+    if (Moment_o < 12.0) Moment_o = 10**(1.5*Moment_o + 9.05)
+    Mw = (alog10(Moment_o) - 9.05) / 1.5
+    
+    !--------------------------------------------------------------------------
+    ! 4. Calculate corner frequencies (as in ffsp_dcf_v2.f90)
+    !--------------------------------------------------------------------------
+    if (Mw < 5.3) then
+        fc_main_1 = 10**(1.474 - 0.415*Mw)
+    else
+        fc_main_1 = 10**(2.375 - 0.585*Mw)
+    endif
+    fc_main_2 = 10**(3.250 - 0.5*Mw)
+    
+    !--------------------------------------------------------------------------
+    ! 5. Initialize main fault
+    !--------------------------------------------------------------------------
+    call mainfault(dip_in, freq_min_in, freq_max_in, rv_avg_in, &
+                   ratio_rise_in, nb_taper_TRBL_in)
+    
+    !--------------------------------------------------------------------------
+    ! 6. Setup geometric parameters
+    !--------------------------------------------------------------------------
+    drp = 4.0 * atan(1.0) / 180.0
+    rstrike = strike_in * drp
+    rdip = dip_in * drp
+    cosx = cos(angle_north_to_x_in * drp)
+    sinx = sin(angle_north_to_x_in * drp)
+    str_ref = (ncxp - 0.5) * dx
+    dip_ref = (ncyp - 0.5) * dy
+    
+    area_sub = 1.e-15
+    if (is_moment_in == 3) area_sub = area_sub / (dx * dy)
+    
+    !--------------------------------------------------------------------------
+    ! 7. Save master seeds (FOR PARALLELIZATION REPRODUCIBILITY)
+    !--------------------------------------------------------------------------
+    idum1_master = seeds_in(1)
+    idum2_master = seeds_in(2)
+    idum3_master = seeds_in(3)
+    
+    !--------------------------------------------------------------------------
+    ! 8. Loop over realizations
+    !--------------------------------------------------------------------------
+    i_real = 0
+    do nsource = id_ran1_in, id_ran2_in
+        i_real = i_real + 1
+        
+        ! Calculate unique seeds for this model (PARALLELIZATION)
+        idum1 = idum1_master + (nsource - 1) * 10000
+        idum2 = idum2_master + (nsource - 1) * 20000
+        idum3 = idum3_master + (nsource - 1) * 30000
+
+        ! idum1 = seeds_in(1)
+        ! idum2 = seeds_in(2)
+        ! idum3 = seeds_in(3)
+
+        ! write(*,*) 'DEBUG fortran: nsource=', nsource
+        ! write(*,*) 'DEBUG fortran: idum1,2,3=', idum1, idum2, idum3
+        ! idum1 = 52  ! Hardcoded para debug
+        ! idum2 = 448
+        ! idum3 = 4446
+   
+        ! Generate random field
+        call random_field(idum1, idum2, idum3, ave_tr, ave_tp, ave_vr, err_spectra)
+        
+        ! Calculate PDF (quality metric)
+        pdf = ((log(ave_tr) - log(rstm_mean + pktm_mean)) / 0.1)**2.0
+        pdf = pdf + ((log(ave_tp) - log(pktm_mean)) / 0.1)**2.0
+        pdf = pdf + err_spectra
+        
+        ! Save statistics
+        ave_tr_out(i_real) = ave_tr
+        ave_tp_out(i_real) = ave_tp
+        ave_vr_out(i_real) = ave_vr
+        err_spectra_out(i_real) = err_spectra
+        pdf_out(i_real) = pdf
+        
+        ! Save source parameters
+        do i = 1, nsubx
+            do j = 1, nsuby
+                k = (i - 1) * nsuby + j
+                
+                ! Calculate coordinates
+                xij = (i - 0.5) * dx - str_ref
+                yij = (j - 0.5) * dy - dip_ref
+                xs = xij * cos(rstrike) - yij * sin(rstrike) * cos(rdip)
+                ys = xij * sin(rstrike) + yij * cos(rstrike) * cos(rdip)
+                xps = xref_hypc_in + xs * cosx + ys * sinx
+                yps = yref_hypc_in - xs * sinx + ys * cosx
+                zps = depth_hypc + yij * sin(rdip)
+                
+                ! Conversion factor
+                factor = 1.0
+                if (is_moment_in > 1) factor = area_sub / amu(k)
+                
+                ! Perturbations
+                dipi = dip_in + dip_prt(k) * pdip_max_in
+                rakei = rake_in + rake_prt(k) * prake_max_in
+                
+                ! Save to output arrays (in meters)
+                x_out(k, i_real) = xps * 1000.0
+                y_out(k, i_real) = yps * 1000.0
+                z_out(k, i_real) = zps * 1000.0
+                slip_out(k, i_real) = slip(k) * factor
+                rupture_time_out(k, i_real) = rptm(k)
+                rise_time_out(k, i_real) = rstm(k)
+                peak_time_out(k, i_real) = pktm(k)
+                strike_out(k, i_real) = strike_in
+                dip_out(k, i_real) = dipi
+                rake_out(k, i_real) = rakei
+            enddo
+        enddo
+    enddo
+    
+    !--------------------------------------------------------------------------
+    ! 9. Calculate spectral data for best realization
+    !--------------------------------------------------------------------------
+    ! Find best realization (minimum PDF)
+    best_idx = minloc(pdf_out(1:n_realizations_out), 1)
+    
+    ! Compute spectral data
+    call compute_spectral_data(smoment, fc_main_1, fc_main_2, &
+         ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
+         stf_time_out, stf_out, &
+         freq_spec_out, moment_rate_out, dcf_out, &
+         freq_center_out, logmean_synth_out, logmean_dcf_out)
+    
+end subroutine ffsp_run_wrapper
+
+!==============================================================================
+! compute_spectral_data
+! Calculates spectral data (STF, spectrum, octave-averaged) for best realization
+! Based on stf_synth_output from dcf_subs_1.f90
+!==============================================================================
+subroutine compute_spectral_data(rmt, fc1, fc2, &
+     ntime_out, nphf_out, lnpt_out, &
+     stf_time, stf, &
+     freq_spec, moment_rate, dcf, &
+     freq_center, logmean_s, logmean_m)
+    
+    use time_freq
+    implicit NONE
+    
+    ! Input
+    real, intent(in) :: rmt, fc1, fc2
+    
+    ! Output dimensions
+    integer, intent(out) :: ntime_out, nphf_out, lnpt_out
+    
+    ! Output arrays
+    real, dimension(*), intent(out) :: stf_time, stf
+    real, dimension(*), intent(out) :: freq_spec, moment_rate, dcf
+    real, dimension(*), intent(out) :: freq_center, logmean_s, logmean_m
+    
+    ! Local variables
+    integer :: i, j, i1, i2
+    real :: tim, dtmt, sum, f2_temp
+! Windows change: svf moved from stack (131072 reals = 512 KB) to heap.
+! A 512 KB stack array causes stack overflow on Windows where the default
+! thread stack is ~1 MB. Using allocatable puts it on the heap instead.
+    real, allocatable :: svf(:)
+    
+    ! Set output dimensions from time_freq module
+    ntime_out = ntime
+    nphf_out = nphf
+    lnpt_out = lnpt - 1
+    
+    !--------------------------------------------------------------------------
+    ! 1. Calculate STF in time domain
+    !--------------------------------------------------------------------------
+! Windows change: allocate svf on heap (see declaration change above).
+    allocate(svf(ntime))
+    svf = 0.0
+    call sum_point_svf(svf)
+    
+    do i = 1, ntime
+        tim = (i - 1) * dt
+        stf_time(i) = tim
+        stf(i) = svf(i) / rmt
+    enddo
+    
+    !--------------------------------------------------------------------------
+    ! 2. Transform to frequency domain
+    !--------------------------------------------------------------------------
+    call realft(svf, ntime, -1)
+    dtmt = dt / rmt
+    
+    do i = 1, ntime
+        svf(i) = svf(i) * dtmt
+    enddo
+    
+    ! Extract moment rate spectrum
+    do i = 1, nphf - 1
+        moment_rate(i) = sqrt(svf(2*(i-1)+1)**2 + svf(2*(i-1)+2)**2)
+    enddo
+    moment_rate(nphf) = svf(nphf-1)
+    
+    !--------------------------------------------------------------------------
+    ! 3. Calculate DCF target and save frequency spectrum
+    !--------------------------------------------------------------------------
+    do i = 1, nphf
+        freq_spec(i) = freq(i)
+        dcf(i) = 1.0 / ((1.0 + (freq(i)/fc1)**4.0)**0.25) / &
+                        ((1.0 + (freq(i)/fc2)**4.0)**0.25)
+    enddo
+    
+    !--------------------------------------------------------------------------
+    ! 4. Calculate octave-averaged spectrum
+    !--------------------------------------------------------------------------
+    do i = 1, lnpt - 1
+        i1 = 2**(i-1)
+        i2 = 2**i - 1
+        
+        ! Log-mean synthetic
+        sum = 0.0
+        do j = i1, i2
+            sum = sum + log(moment_rate(j))
+        enddo
+        logmean_s(i) = sum / (i2 - i1 + 1)
+        
+        ! Log-mean DCF target
+        sum = 0.0
+        do j = i1, i2
+            sum = sum + log(dcf(j))
+        enddo
+        logmean_m(i) = sum / (i2 - i1 + 1)
+        
+        ! Center frequency of octave
+        freq_center(i) = 0.5 * (freq(i1) + freq(i2))
+    enddo
+    
+! Windows change: deallocate heap array allocated above.
+    deallocate(svf)
+end subroutine compute_spectral_data

--- a/shakermaker/ffsp/ffsp_wrapper.f90
+++ b/shakermaker/ffsp/ffsp_wrapper.f90
@@ -33,6 +33,7 @@ subroutine ffsp_run_wrapper( &
     strike_out, dip_out, rake_out, &
     ! Output: Statistics
     ave_tr_out, ave_tp_out, ave_vr_out, err_spectra_out, pdf_out, &
+    fc_main_1_out, fc_main_2_out, &
     ! Output: Spectral data dimensions
     ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
     ! Output: STF time domain
@@ -102,16 +103,16 @@ subroutine ffsp_run_wrapper( &
     
     ! STF time domain - will be allocated based on ntime from time_freq module
     real, intent(out) :: stf_time_out(131072)  ! Max size (will use only ntime_spec_out)
-    real, intent(out) :: stf_out(131072)
+    real, intent(out) :: stf_out(131072, id_ran2_in-id_ran1_in+1)
     
     ! Spectrum frequency domain
     real, intent(out) :: freq_spec_out(65536)  ! Max size (will use only nphf_spec_out)
-    real, intent(out) :: moment_rate_out(65536)
+    real, intent(out) :: moment_rate_out(65536, id_ran2_in-id_ran1_in+1)
     real, intent(out) :: dcf_out(65536)
     
     ! Octave-averaged spectrum
     real, intent(out) :: freq_center_out(17)  ! Max size (will use only lnpt_spec_out)
-    real, intent(out) :: logmean_synth_out(17)
+    real, intent(out) :: logmean_synth_out(17, id_ran2_in-id_ran1_in+1)
     real, intent(out) :: logmean_dcf_out(17)
     
     !--------------------------------------------------------------------------
@@ -119,10 +120,11 @@ subroutine ffsp_run_wrapper( &
     !--------------------------------------------------------------------------
     integer :: idum1, idum2, idum3
     integer :: idum1_master, idum2_master, idum3_master
-    integer :: nsource, i, j, k, i_real, best_idx
+    integer :: nsource, i, j, k, i_real
     real :: drp, rdip, rstrike, cosx, sinx, str_ref, dip_ref, area_sub
     real :: xij, yij, xs, ys, xps, yps, zps, factor, rakei, dipi
     real :: ave_tr, ave_tp, ave_vr, err_spectra, pdf
+    real, intent(out) :: fc_main_1_out, fc_main_2_out
     
     !--------------------------------------------------------------------------
     ! 0. Clean up previous state (CRITICAL for repeated calls)
@@ -184,12 +186,20 @@ subroutine ffsp_run_wrapper( &
         fc_main_1 = 10**(2.375 - 0.585*Mw)
     endif
     fc_main_2 = 10**(3.250 - 0.5*Mw)
+    fc_main_1_out = fc_main_1
+    fc_main_2_out = fc_main_2
     
     !--------------------------------------------------------------------------
     ! 5. Initialize main fault
     !--------------------------------------------------------------------------
     call mainfault(dip_in, freq_min_in, freq_max_in, rv_avg_in, &
                    ratio_rise_in, nb_taper_TRBL_in)
+
+    ! The axes and DCF target are identical for every realization.
+    call compute_spectral_common(fc_main_1, fc_main_2, &
+         ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
+         stf_time_out, freq_spec_out, dcf_out, &
+         freq_center_out, logmean_dcf_out)
     
     !--------------------------------------------------------------------------
     ! 6. Setup geometric parameters
@@ -219,23 +229,33 @@ subroutine ffsp_run_wrapper( &
     do nsource = id_ran1_in, id_ran2_in
         i_real = i_real + 1
         
-        ! Calculate unique seeds for this model (PARALLELIZATION)
-        idum1 = idum1_master + (nsource - 1) * 10000
+        ! Derive the random stream from the master seeds and the GLOBAL realization
+        ! id.  This must not depend on the MPI rank, batch limits, or call history.
+        !
+        ! TRACEABILITY (seed audit, 2026-07): ran3 in ffsp_tool.f is Numerical
+        ! Recipes ran1 and keeps iv/iy in SAVE variables.  On a fresh process a
+        ! positive idum enters its initialization branch and max(-idum,1) maps
+        ! every positive seed to 1.  Consequently, the first realization handled
+        ! by every MPI rank used to start from the same slip random field.
+        !
+        ! A negative idum1 forces an explicit reset before EVERY realization.  The
+        ! first realization uses -1 to retain the historical reference FFSP stream;
+        ! subsequent realizations use seed1 plus the global-id offset.  idum2 and
+        ! idum3 intentionally keep the reference positive-offset convention: they
+        ! continue from the known state established by idum1 inside this realization.
+        if (nsource == 1) then
+            idum1 = -1
+        else
+            idum1 = -abs(idum1_master + (nsource - 1) * 10000)
+        endif
         idum2 = idum2_master + (nsource - 1) * 20000
         idum3 = idum3_master + (nsource - 1) * 30000
-
-        ! idum1 = seeds_in(1)
-        ! idum2 = seeds_in(2)
-        ! idum3 = seeds_in(3)
-
-        ! write(*,*) 'DEBUG fortran: nsource=', nsource
-        ! write(*,*) 'DEBUG fortran: idum1,2,3=', idum1, idum2, idum3
-        ! idum1 = 52  ! Hardcoded para debug
-        ! idum2 = 448
-        ! idum3 = 4446
    
         ! Generate random field
-        call random_field(idum1, idum2, idum3, ave_tr, ave_tp, ave_vr, err_spectra)
+        call random_field_with_spectra(idum1, idum2, idum3, ave_tr, ave_tp, ave_vr, &
+             err_spectra, stf_out(1:ntime_spec_out,i_real), &
+             moment_rate_out(1:nphf_spec_out,i_real), &
+             logmean_synth_out(1:lnpt_spec_out,i_real))
         
         ! Calculate PDF (quality metric)
         pdf = ((log(ave_tr) - log(rstm_mean + pktm_mean)) / 0.1)**2.0
@@ -286,53 +306,33 @@ subroutine ffsp_run_wrapper( &
         enddo
     enddo
     
-    !--------------------------------------------------------------------------
-    ! 9. Calculate spectral data for best realization
-    !--------------------------------------------------------------------------
-    ! Find best realization (minimum PDF)
-    best_idx = minloc(pdf_out(1:n_realizations_out), 1)
-    
-    ! Compute spectral data
-    call compute_spectral_data(smoment, fc_main_1, fc_main_2, &
-         ntime_spec_out, nphf_spec_out, lnpt_spec_out, &
-         stf_time_out, stf_out, &
-         freq_spec_out, moment_rate_out, dcf_out, &
-         freq_center_out, logmean_synth_out, logmean_dcf_out)
-    
 end subroutine ffsp_run_wrapper
 
 !==============================================================================
-! compute_spectral_data
-! Calculates spectral data (STF, spectrum, octave-averaged) for best realization
-! Based on stf_synth_output from dcf_subs_1.f90
+! compute_spectral_common
+! Calculates axes and the DCF target shared by every realization.
 !==============================================================================
-subroutine compute_spectral_data(rmt, fc1, fc2, &
+subroutine compute_spectral_common(fc1, fc2, &
      ntime_out, nphf_out, lnpt_out, &
-     stf_time, stf, &
-     freq_spec, moment_rate, dcf, &
-     freq_center, logmean_s, logmean_m)
+     stf_time, freq_spec, dcf, freq_center, logmean_m)
     
     use time_freq
     implicit NONE
     
     ! Input
-    real, intent(in) :: rmt, fc1, fc2
+    real, intent(in) :: fc1, fc2
     
     ! Output dimensions
     integer, intent(out) :: ntime_out, nphf_out, lnpt_out
     
     ! Output arrays
-    real, dimension(*), intent(out) :: stf_time, stf
-    real, dimension(*), intent(out) :: freq_spec, moment_rate, dcf
-    real, dimension(*), intent(out) :: freq_center, logmean_s, logmean_m
+    real, dimension(*), intent(out) :: stf_time
+    real, dimension(*), intent(out) :: freq_spec, dcf
+    real, dimension(*), intent(out) :: freq_center, logmean_m
     
     ! Local variables
     integer :: i, j, i1, i2
-    real :: tim, dtmt, sum, f2_temp
-! Windows change: svf moved from stack (131072 reals = 512 KB) to heap.
-! A 512 KB stack array causes stack overflow on Windows where the default
-! thread stack is ~1 MB. Using allocatable puts it on the heap instead.
-    real, allocatable :: svf(:)
+    real :: tim, sum
     
     ! Set output dimensions from time_freq module
     ntime_out = ntime
@@ -340,39 +340,18 @@ subroutine compute_spectral_data(rmt, fc1, fc2, &
     lnpt_out = lnpt - 1
     
     !--------------------------------------------------------------------------
-    ! 1. Calculate STF in time domain
+    ! 1. Calculate shared time axis
     !--------------------------------------------------------------------------
-! Windows change: allocate svf on heap (see declaration change above).
-    allocate(svf(ntime))
-    svf = 0.0
-    call sum_point_svf(svf)
-    
     do i = 1, ntime
         tim = (i - 1) * dt
         stf_time(i) = tim
-        stf(i) = svf(i) / rmt
     enddo
-    
-    !--------------------------------------------------------------------------
-    ! 2. Transform to frequency domain
-    !--------------------------------------------------------------------------
-    call realft(svf, ntime, -1)
-    dtmt = dt / rmt
-    
-    do i = 1, ntime
-        svf(i) = svf(i) * dtmt
-    enddo
-    
-    ! Extract moment rate spectrum
-    do i = 1, nphf - 1
-        moment_rate(i) = sqrt(svf(2*(i-1)+1)**2 + svf(2*(i-1)+2)**2)
-    enddo
-    moment_rate(nphf) = svf(nphf-1)
     
     !--------------------------------------------------------------------------
     ! 3. Calculate DCF target and save frequency spectrum
     !--------------------------------------------------------------------------
     do i = 1, nphf
+        freq(i) = (i - 1 + 1.0e-5) * df
         freq_spec(i) = freq(i)
         dcf(i) = 1.0 / ((1.0 + (freq(i)/fc1)**4.0)**0.25) / &
                         ((1.0 + (freq(i)/fc2)**4.0)**0.25)
@@ -385,13 +364,6 @@ subroutine compute_spectral_data(rmt, fc1, fc2, &
         i1 = 2**(i-1)
         i2 = 2**i - 1
         
-        ! Log-mean synthetic
-        sum = 0.0
-        do j = i1, i2
-            sum = sum + log(moment_rate(j))
-        enddo
-        logmean_s(i) = sum / (i2 - i1 + 1)
-        
         ! Log-mean DCF target
         sum = 0.0
         do j = i1, i2
@@ -403,6 +375,4 @@ subroutine compute_spectral_data(rmt, fc1, fc2, &
         freq_center(i) = 0.5 * (freq(i1) + freq(i2))
     enddo
     
-! Windows change: deallocate heap array allocated above.
-    deallocate(svf)
-end subroutine compute_spectral_data
+end subroutine compute_spectral_common

--- a/shakermaker/ffsp/makefile
+++ b/shakermaker/ffsp/makefile
@@ -1,0 +1,38 @@
+F90     = gfortran -O3
+F77     = gfortran -O3 -std=legacy
+
+OBJ	      = ffsp_tool.o \
+		ffsp_comm.o \
+		slip_rate.o \
+		spfield_n.o \
+		dcf_subs_1.o\
+
+all:		ffsp_dcf_v2 s2m install
+
+ffsp_dcf_v2:     $(OBJ) ffsp_dcf_v2.f90
+		$(F90) $(OBJ) -o $@ $@.f90 
+
+s2m:		s2m.f90 s2m_comm.o
+		$(F90) s2m.f90 s2m_comm.o -o $@
+
+ffsp_tool.o:  ffsp_tool.f
+		$(F77) -c ffsp_tool.f
+s2m_comm.o:	s2m_comm.f90
+		$(F90) -c s2m_comm.f90
+ffsp_comm.o:  ffsp_comm.f90
+		$(F90) -c ffsp_comm.f90
+slip_rate.o:  slip_rate.f90
+		$(F90) -c slip_rate.f90
+spfield_n.o:  spfield_n.f90
+		$(F90) -c spfield_n.f90
+dcf_subs_1.o:  dcf_subs_1.f90
+		$(F90) -c dcf_subs_1.f90
+
+install:
+	#cp ffsp_dcf_v2 ../
+	#cp s2m ../
+	@echo "Install step skipped"
+
+clean:		
+	rm -f *.o *.mod s2m ffsp_dcf_v2
+

--- a/shakermaker/ffsp/s2m.f90
+++ b/shakermaker/ffsp/s2m.f90
@@ -1,0 +1,269 @@
+Program single2multiple
+!use sp_sub_f
+use source_params_all
+implicit NONE
+!
+! By the definition of Liu et al. (2006),
+!  xij=(i-0.5)*dx-str_ref
+!  yij=(j-0.5)*dy-dip_ref
+!
+! Then, the single fault plane is defined as
+! 1. includes all fault segments
+! 2. inlcudes the fault segment with hypocenter
+!
+
+character(len=72):: vsfile,spfile,spfile_best,spfile_best_m
+integer, dimension(4):: nb_taper_TRBL
+integer:: getlen,idum1,idum2,idum3,id_ran1,id_ran2,&
+      nsource,i,j,k,nlch
+real:: sp2,drp,rdip,rstrike,cosx,sinx,str_ref,dip_ref,area_sub, &
+       summ,rmt,rvc,xij,yij,xs,ys,xps,yps,zps,factor,rakei,dipi,&
+       pamzi,pdip_max,prake_max
+real::xstk,rise_time,x_hypc_n, y_hypc_n,Moment_o
+integer::io_model_out,id_min,nfs,id
+
+open(8,file='ffsp.inp',status='old')
+!write(7,*) 'Enter the index of slip rate function'
+read(8,*)  id_sf_type, freq_min, freq_max
+
+!write(7,*) ' Enter the length and width of main fault'
+read(8,*)  flx,fwy
+
+!write(7,*) ' Enter the distance in the strike and down dip'
+!write(7,*) ' direction, and the depth of the hypocenter'
+read(8,*)  x_hypc, y_hypc, depth_hypc
+
+!write(7,*) 'Enter the coordinates  of hypocenter'
+read(8,*)  xref_hypc,yref_hypc
+
+!write(7,*) 'Enter the moment(N-m), corner frequency(Hz) and ', &
+!           'Average rupture speed'
+
+read(8,*)  Moment_o,fc_main_1,fc_main_2,rv_avg
+
+!write(7,*) 'Enter the ratio of time between slip-rate increase', &
+!           ' and rise time'
+
+read(8,*)  cft1
+!write(7,*) cft1
+
+!write(7,*) ' Enter the strike, dip and rake of main fault'
+read(8,*)  strike,dip,rake
+
+!write(7,*) 'Enter Max. perturbation on the dip and rake'
+read(8,*)  pdip_max,prake_max
+
+!write(7,*) ' Enter the subfaults number along strike adn dip'
+read(8,*)  nsubx,nsuby
+
+!write(7,*) ' Enter the numbers of subfault to be tapered at each side'
+!           Top-Right-Bottom-Left
+read(8,*)  (nb_taper_TRBL(i), i=1,4)
+
+!write(7,*) ' Enter the seed for generating random numbers'
+read(8,*)  idum1,idum2,idum3
+
+!write(7,*)'Enter first and last index of random generations'
+read(8,*)  id_ran1,id_ran2
+
+!write(7,*) ' Enter the name of file with velocity', &
+!           ' structure of source region'
+read(8,'(1a)')  vsfile
+!write(7,'(1a)') vsfile
+!
+!  The Parameters for outputing results
+!
+!write(7,*) 'Enter the angle (degree) from North to X-Axis (clockwise) of SYN. code'
+read(8,*)  angle_north_to_x
+
+if(abs(angle_north_to_x).gt.1.0e-6)THEN
+  write(*,*)"In the corrent version, this must be fixed to zero"
+  stop
+endif
+
+!write(7,*) 'Do you output moment(1), slip-area (2), or slip(3) '
+read(8,*)  is_moment
+
+!write(7,*) ' Enter the file name of output source parameters'
+read(8,'(1a)')  spfile
+! read in the information of multiple segments
+
+read(8,*)n_fault_segment
+nfs=n_fault_segment
+allocate(x_stk_min(nfs),x_stk_max(nfs),y_dip_min(nfs),y_dip_max(nfs), &
+        seg_stk(nfs),seg_dip(nfs),seg_rake(nfs),seg_upleft_n(nfs),&
+        seg_upleft_e(nfs),seg_upleft_z(nfs),io_reverse(nfs))
+
+do i=1,n_fault_segment
+  read(8,*)id_segment
+  read(8,*)x_stk_min(i),x_stk_max(i)
+  if(x_stk_min(i).gt.x_stk_max(i))THEN
+    io_reverse(i)=1
+    xstk=x_stk_min(i)
+    x_stk_min(i)=x_stk_max(i)
+    x_stk_max(i)=xstk
+  else
+    io_reverse(i)=0
+  endif
+  read(8,*)y_dip_min(i),y_dip_max(i)
+  read(8,*)seg_stk(i),seg_dip(i),seg_rake(i)
+! up-left position of fault segment relative to epicenter
+  read(8,*)seg_upleft_n(i),seg_upleft_e(i),seg_upleft_z(i)
+  write(*,*)seg_upleft_n(i),seg_upleft_e(i),seg_upleft_z(i)
+enddo
+close(8)
+!
+open(11,file='source_model.list',status='old')
+read(11,118) id, nsubx, nsuby, dx, dy, x_hypc_n, y_hypc_n
+read(11,119) xref_hypc, yref_hypc, angle_north_to_x
+read(11,'(1a)') spfile_best
+close(11)
+nlch=len_trim(spfile_best)+1
+spfile_best_m=spfile_best
+spfile_best_m(nlch:nlch+1)="_m"
+open(11,file='source_model.list_m')
+write(11,118) id, nsubx, nsuby, dx, dy, x_hypc_n, y_hypc_n
+write(11,119) xref_hypc, yref_hypc, angle_north_to_x
+write(11,'(1a)') spfile_best_m
+close(11)
+118     format(I3, 2I5, 4e15.7)
+119     format(3e15.7)
+
+call input_source_param(spfile_best,spfile_best_m)
+
+do  i=1,nsubx
+do  j=1,nsuby
+  k=(i-1)*nsuby+j
+  xij=(i-0.5)*dx-str_ref
+  yij=(j-0.5)*dy-dip_ref
+  xs=xij*cos(rstrike)-yij*sin(rstrike)*cos(rdip)
+  ys=xij*sin(rstrike)+yij*cos(rstrike)*cos(rdip)
+  xps=xref_hypc  + xs*cosx+ys*sinx
+  yps=yref_hypc  - xs*sinx+ys*cosx
+  zps=depth_hypc + yij*sin(rdip)
+end do
+end do
+
+end program single2multiple
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+subroutine input_source_param(filesour,fileout)
+! Read the source parameters
+ use source_params_all
+ implicit NONE
+ character(len=72):: filesour,fileout
+ !integer, intent(IN):: ncx,ncy
+ integer:: i,j,nfs,is,ks,nx_ref
+ real:: dr,rstrike,rdip,xij,yij,cosx,sinx
+ real:: drp,str_ref,dip_ref,xps,zps,yps,xs,ys
+!
+ write(*,1)filesour
+ write(*,1)fileout
+ !
+ 1 format(a)
+ open(unit=19, file=filesour,status='old')
+ open(unit=29, file=fileout,status='unknown')
+ read(19,*) is_moment,npsour,id_sf_type,cft1
+ write(29,*) is_moment,npsour,id_sf_type,cft1
+!
+!nps_sub=nsubx*nsuby
+
+ if(allocated(ps_xn)) then
+    deallocate(ps_xn,ps_ye,ps_dz,ps_mt,ps_rp, &
+               ps_rs,ps_p2,ps_sk,ps_dp,ps_rk,drtx,drty, &
+               xps_sub,yps_sub,zps_sub )
+    deallocate(nx_stk_max,nx_stk_min,ny_dip_max,ny_dip_min)
+ endif
+ allocate(ps_xn(npsour),ps_ye(npsour),ps_dz(npsour),ps_mt(npsour), &
+          ps_rp(npsour),ps_rs(npsour),ps_p2(npsour),ps_sk(npsour), &
+          ps_dp(npsour),ps_rk(npsour),drtx(npsour),drty(npsour) )
+ allocate(xps_sub(nps_sub),yps_sub(nps_sub),zps_sub(nps_sub))
+ allocate(nx_stk_max(nps_sub),nx_stk_min(nps_sub),ny_dip_max(nps_sub), &
+          ny_dip_min(nps_sub))
+!
+ write(*,*)npsour
+
+ do ks=1,npsour
+   read(19,*) ps_xn(ks),ps_ye(ks),ps_dz(ks),ps_mt(ks),ps_rp(ks), &
+              ps_rs(ks),ps_p2(ks),ps_sk(ks),ps_dp(ks),ps_rk(ks)
+ enddo
+ close(19)
+!
+! The above do loop over subfaults (or point sources)
+!
+! 1-3.  are the coornidates in meters (North, East, Down) of each point source.
+! 4-7.  are the moment (N-m), rupture time (s), rise time(s), and another source
+!       parameters (any value if not used)
+!
+! 8-10. are the strike, dip, and rake in degree
+!
+
+ do ks=1,npsour
+   ps_xn(ks)=ps_xn(ks)/1000.0
+   ps_ye(ks)=ps_ye(ks)/1000.0
+   ps_dz(ks)=ps_dz(ks)/1000.0
+ enddo
+ drp=acos(-1.0)/180.0
+ cosx=cos(angle_north_to_x*drp)
+ sinx=sin(angle_north_to_x*drp)
+! str_ref=(ncx-0.5)*dx
+! dip_ref=(ncy-0.5)*dy
+ write(*,*)npsour,cosx,sinx,drp
+ dx=dx/1000.0
+ dy=dy/1000.0
+ do is=1,n_fault_segment
+   nx_stk_min(is)=int(x_stk_min(is)/dx-0.5)+1
+
+   nx_stk_max(is)=int(x_stk_max(is)/dx-0.5)+1
+
+   if(io_reverse(is).gt.0)then
+     nx_ref=nx_stk_min(is)
+   else
+     nx_ref=nx_stk_max(is)
+   endif
+   ny_dip_min(is)=int(y_dip_min(is)/dy-0.5)+1
+   ny_dip_max(is)=int(y_dip_max(is)/dy-0.5)+1
+
+   rstrike=seg_stk(is)*drp
+   rdip=seg_dip(is)*drp
+   cosx=cos(angle_north_to_x*drp)
+   sinx=sin(angle_north_to_x*drp)
+   write(*,*)x_stk_min(is),x_stk_max(is),is,dx,dy
+   write(*,*)"****",nx_stk_max(is),nx_stk_min(is),ny_dip_min(is),ny_dip_max(is)
+   write(*,*)seg_upleft_z(is),io_reverse(is)
+   write(*,*)seg_rake(is),rake
+   write(*,*)seg_dip(is),dip
+   write(*,*)seg_stk(is),strike
+   do i=1,nx_stk_max(is)-nx_stk_min(is)+1
+     do j=1,ny_dip_max(is)-ny_dip_min(is)+1
+       if(io_reverse(is).eq.0)then
+         ks=(i+nx_stk_min(is)-2)*nsuby+j+ny_dip_min(is)-1
+       else
+         ks=(nx_stk_max(is)-i)*nsuby+j+ny_dip_min(is)-1
+       endif
+       xij=(i-0.5)*dx
+       yij=(j-0.5)*dy
+       xs=xij*cos(rstrike)-yij*sin(rstrike)*cos(rdip)
+       ys=xij*sin(rstrike)+yij*cos(rstrike)*cos(rdip)
+       xps=seg_upleft_n(is) + xs*cosx+ys*sinx
+       yps=seg_upleft_e(is) - xs*sinx+ys*cosx
+       zps=seg_upleft_z(is) + yij*sin(rdip)
+       if(i.eq.1.and.j.eq.1)write(*,*)i,j,is,ks,zps
+       ps_rk(ks)=ps_rk(ks)+(seg_rake(is)-rake)
+       ps_dp(ks)=ps_dp(ks)+(seg_dip(is)-dip)
+       ps_sk(ks)=ps_sk(ks)+(seg_stk(is)-strike)
+       ps_xn(ks)=xps*1000.0
+       ps_ye(ks)=yps*1000.0
+       ps_dz(ks)=zps*1000.0
+!       write(29,109)xps*1000.,yps*1000.,zps*1000.,ps_mt(ks),ps_rp(ks), &
+!                  ps_rs(ks),ps_p2(ks),ps_sk(ks),ps_dp(ks),ps_rk(ks)
+     end do
+   end do
+ end do
+ do ks=1,npsour
+   write(29,109) ps_xn(ks),ps_ye(ks),ps_dz(ks),ps_mt(ks),ps_rp(ks), &
+              ps_rs(ks),ps_p2(ks),ps_sk(ks),ps_dp(ks),ps_rk(ks)
+ enddo
+ close(29)
+ 109     format(4e15.7,6e12.4)
+end subroutine input_source_param

--- a/shakermaker/ffsp/s2m_comm.f90
+++ b/shakermaker/ffsp/s2m_comm.f90
@@ -1,0 +1,29 @@
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+MODULE source_params_all
+ implicit NONE
+ save
+
+ integer:: nsubx,nsuby,npsour,nps_sub,is_moment,id_sf_type,npt,kfb,kfe
+ integer, allocatable, dimension(:,:):: ind4_sub
+ real:: dxsub,dysub,cxp,cyp,xref_hypc,yref_hypc,angle_north_x,dt,cft1
+ real, allocatable, dimension(:):: ps_xn,ps_ye,ps_dz,ps_mt,ps_rp, &
+                         ps_rs,ps_p2,ps_sk,ps_dp,ps_rk,drtx,drty, &
+                         sh_strk,sh_dip,xps_sub,yps_sub,zps_sub
+ real, allocatable, dimension(:):: strk_bud,dip_bud,rake_bud,rd_wl, &
+                                   fsour,syn_up,syn_h1,syn_h2,syn_tmp
+ real, allocatable, dimension(:,:):: gfun,green_ps,rad_h1,rad_h2,rad_vt
+ real, allocatable, dimension(:,:):: coef4_ps
+!
+real::flx,fwy,strike,dip,rake
+real::freq_min,freq_max
+real::x_hypc, y_hypc, depth_hypc
+real::angle_north_to_x,rv_avg
+real::dx,dy,fc_main_1,fc_main_2
+!
+ integer::n_fault_segment,id_segment
+ integer, allocatable, dimension(:)::io_reverse,nx_stk_max,nx_stk_min,ny_dip_max,ny_dip_min
+ real, allocatable, dimension(:):: x_stk_min,x_stk_max,y_dip_min,y_dip_max
+ real, allocatable, dimension(:):: seg_stk,seg_dip,seg_rake
+ real, allocatable, dimension(:):: seg_upleft_n,seg_upleft_e,seg_upleft_z
+
+END MODULE source_params_all

--- a/shakermaker/ffsp/slip_rate.f90
+++ b/shakermaker/ffsp/slip_rate.f90
@@ -1,0 +1,190 @@
+!======================================================================
+! The subroutines in this file are for generating the slip rate
+! functions for each point source, and sum them together to get
+! spectra of larget event
+!
+! Written by Pengcheng Liu
+! Copyright (c) 2005 by Pengcheng Liu
+!
+!  Simply using the modified yoffe function as default
+!         Chen Ji, 2020
+!======================================================================
+subroutine sum_point_svf(svf)
+ use time_freq
+ use sp_sub_f
+ implicit NONE
+ integer:: i,j,j0,j1,j2,jmm
+ real:: rise_time
+! Windows change: svf_s and mr changed from stack arrays to heap (allocatable).
+! Stack arrays of size ntime (131072 reals = 512 KB each) cause stack overflow on Windows.
+ real, dimension(ntime):: svf
+ real, allocatable:: svf_s(:), mr(:)
+  allocate(svf_s(ntime), mr(2*ntime))
+  svf=0.0
+  mr=0.0
+ do i=1,nsum
+   rise_time=rstm(i)+pktm(i)
+   cft1=pktm(i)/rise_time
+! Windows change: pass ntime as nsvf so svf_yoffe uses explicit-size interface.
+   call svf_yoffe(ntime,dt,rise_time,cft1,svf_s,ntime)
+   j0=int(rptm(i)/dt+0.5)
+   j1=j0+1
+   j2=int(rise_time/dt)+j1
+   do j=j1,j2
+! Windows change: bounds guards prevent out-of-bounds write that crashes
+! silently on Windows/ifx (Linux/gfortran tolerates it due to memory layout).
+     if(j.ge.1 .and. j.le.2*ntime .and. &
+        (j-j0).ge.1 .and. (j-j0).le.ntime) then
+       mr(j)=mr(j)+slip(i)*svf_s(j-j0)
+     endif
+   enddo
+ enddo
+ do i=1,ntime
+    svf(i)=mr(i)
+ enddo
+! Windows change: deallocate heap arrays allocated above.
+ deallocate(svf_s, mr)
+end subroutine sum_point_svf
+!
+!======================================================================
+!
+subroutine peak_slip_rate(pksr)
+ use time_freq
+ use sp_sub_f
+ implicit NONE
+ real, dimension(nsum):: pksr
+ integer:: i
+!
+! just for modified yoffe function
+!         Chen Ji, 2020
+ do i=1,nsum
+   pksr(i)=slip(i)/sqrt(pktm(i))/sqrt(rstm(i))
+ end do
+
+end subroutine peak_slip_rate
+!
+!======================================================================
+! modified normalized yoffe function. Chen Ji, 2020
+!
+! Windows change: added nsvf argument so svf uses explicit-size declaration svf(nsvf).
+! Passing an assumed-shape (dimension(:)) or fixed-size array from an allocatable
+! caller without an explicit interface is illegal Fortran 90 and causes heap
+! corruption on Windows/ifx (crash inside allocate). Explicit-size passes by
+! address only — no array descriptor, no interface needed, legal on all compilers.
+! yoffe and hsin also moved to heap (allocatable) to avoid 3x512 KB on the stack.
+subroutine svf_yoffe(nt,dt,rise_time,cft1,svf,nsvf)
+ implicit NONE
+ real, parameter:: pi=3.14159265
+ integer:: nt,nsvf,npt_yoffe,nsin,i,j,nall
+ real:: cft1,dt,rise_time
+ real:: ty,tsin,sn,t,tsin_min
+! Windows change: svf explicit-size (no descriptor), yoffe/hsin heap-allocated.
+ real,intent(out):: svf(nsvf)
+ real,allocatable:: yoffe(:),hsin(:)
+ allocate(yoffe(nt),hsin(nt))
+ yoffe=0.0
+ hsin=0.0
+
+ svf=0.0
+ if(cft1.ge.1.0)then
+    write(*,*)"unphysical rise-time function"
+    stop
+ endif
+ tsin_min=2.0*dt
+ tsin=cft1*rise_time
+ ty=rise_time-Tsin
+ npt_yoffe=int(ty/dt+1)+1
+ nsin=int(tsin/dt+0.1)+1
+ nall=npt_yoffe+nsin
+ do i=1,npt_yoffe
+    t=i*dt
+    if(t.le.ty)then
+       yoffe(i)=sqrt(ty-t)/sqrt(t)
+    else
+       yoffe(i)=0.0
+    endif
+ enddo
+ if(tsin.ge.tsin_min)then
+   do i=1,nsin
+     t=(i-1)*dt
+     if(t.le.tsin)then
+       hsin(i)=sin(t*pi/tsin)
+     else
+       hsin(i)=0.0
+     endif
+   enddo
+   do i=1,npt_yoffe
+     do j=1,nsin
+! Windows change: guard prevents write past end of svf(nsvf).
+       if((i+j-1).le.nsvf) svf(i+j-1)=svf(i+j-1)+yoffe(i)*hsin(j)
+     enddo
+   enddo
+ else
+   do i=1,npt_yoffe
+     svf(i)=yoffe(i)
+   enddo
+ endif
+ sn=0.0
+ do i=1,nall
+    sn=sn+svf(i)
+ enddo
+! Windows change: guard against division by zero if sn=0 after clamping.
+ if(sn.ne.0.0) svf=svf/(dt*sn)
+! Windows change: deallocate heap arrays.
+ deallocate(yoffe,hsin)
+end subroutine svf_yoffe
+!
+!======================================================================
+! modified normalized kostrov function at r/v=10
+! t0 and t02
+subroutine svf_kostrov(nt,dt,rise_time,cft1,svf)
+ implicit NONE
+ real, parameter:: pi=3.14159265,t0=10.0,t02=t0*t0
+ integer:: nt,npt_kostrov,nsin,i,j
+ real:: cft1,dt,rise_time
+ real:: tk,tsin,sn,t
+ real,dimension(nt):: svf,yk,hsin
+
+ svf=0.0
+ if(cft1.gt.1.0)then
+    write(*,*)"unphysical rise-time function"
+    stop
+ endif
+
+ tsin=cft1*rise_time
+ tk=rise_time-Tsin
+ npt_kostrov=int(tk/dt+1.0)+1
+ nsin=int(tsin/dt+1.0)+1
+
+ yk(1)=0.0
+ do i=2,npt_kostrov
+    t=(i-1)*dt
+    if(t.le.tk)then
+       yk(i)=(t+t0)/sqrt((t+t0)**2.0 -t02)
+    else
+       yk(i)=0.0
+    endif
+ enddo
+
+ do i=1,nsin
+    t=(i-1)*dt
+    if(t.le.tsin)then
+       hsin(i)=sin((i-1)*dt*pi/tsin)
+    else
+       hsin(i)=0.0
+    endif
+ enddo
+ do i=1,npt_kostrov
+    do j=1,nsin
+        svf(i+j-1)=svf(i+j-1)+yk(i)*hsin(j)
+    enddo
+ enddo
+ do i=1,npt_kostrov+nsin-1
+    svf(i)=svf(i+1)
+ enddo
+ sn=0.0
+ do i=1,npt_kostrov+nsin-1
+    sn=sn+svf(i)
+ enddo
+ svf=svf/(dt*sn)
+end subroutine svf_kostrov

--- a/shakermaker/ffsp/spfield_n.f90
+++ b/shakermaker/ffsp/spfield_n.f90
@@ -1,0 +1,1340 @@
+! spfield.f90
+! The subroutines in this file are for generating the spatial
+! distribution of source parameters on main-fault
+!
+! Written by Pengcheng Liu
+! Copyright (c) 2005 by Pengcheng Liu
+!
+! Modifications by Chen Ji
+!      1. Using Gusey approach to define the rupture front
+!      2. using dcf to constrain the spectral level
+!      3. frequency band used to constrain the model
+!      4. using low-fc to constrain the rupture Velocity
+!      5. using the high-fc to initialize the mean rise time
+!======================================================================
+subroutine mainfault(dip,freq_min,freq_max,rv_avg,ratio_rise,nb_taper_TRBL)
+! Set the initial parameters for generating the source paramters
+! flx,flw-- fault length (in strike) and width (in dip)
+! the spectrum between freq_min and freq_max will be used to constrain the model
+!
+ use sp_sub_f
+ use fdtim_2d
+ use time_freq
+ implicit NONE
+ integer,dimension(4), intent(IN):: nb_taper_TRBL
+ real, intent(IN):: dip,freq_max,freq_min,rv_avg,ratio_rise
+ integer:: i,j,k,lyr,nb,ll,nx1,ny1
+ real:: rdip,yij,hk,sumh,sv,sm,rat,ttmp,vs_avg
+!
+ cft1=ratio_rise
+ nsum=nsubx*nsuby
+ dx=flx/nsubx
+ dy=fwy/nsuby
+!
+! why 1e-15?  dx dy in km -->10^-6, beta and density in km and ton ->10^-9
+!
+ smoment= Moment_o*1.e-15
+!
+! grid_2d <0.2 km, in contrast, 1 km in GP, 0.33km in Frankel
+!
+ grid_2d=amin1(0.2,  amin1(dx,dy))
+! nx_2d: >= nsubx
+! nz_2d: >= nsuby
+
+! redefine the hypocenter location
+
+ nx_2d=int((nsubx-1)*dx/grid_2d)+2
+ nz_2d=int((nsuby-1)*dy/grid_2d)+2
+ ncxp=int(x_hypc/dx) + 1
+ ncyp=int(y_hypc/dy) + 1
+ cxp=(ncxp-0.5)*dx
+ cyp=(ncyp-0.5)*dy
+ x_hypc=cxp
+ y_hypc=cyp
+!
+ if(allocated(slip)) deallocate(slip,rstm,rptm,pktm,rpvel,beta,amu, &
+                     taper,rtx,rtz,rake_prt,dip_prt,amz_prt,depth_source)
+ allocate(slip(nsum),rstm(nsum),rptm(nsum),pktm(nsum),lrtp(nsum),rpvel(nsum), &
+          beta(nsum),amu(nsum),taper(nsum),rtx(nsum),rtz(nsum))
+ allocate(rake_prt(nsum),dip_prt(nsum),amz_prt(nsum),depth_source(nsuby))
+!
+ rdip=dip*4.*atan(1.0)/180.0
+ do j=1,nsuby
+   yij=(j-0.5)*dy-cyp
+   hk=yij*sin(rdip)+depth_hypc
+   depth_source(j)=hk
+   thk(layer)=hk+0.5
+   lyr=0
+   sumh=0
+   do while(hk > sumh)
+     lyr=lyr+1
+     sumh=sumh+thk(lyr)
+   enddo
+!
+   sv=vvs(lyr)
+   sm=roh(lyr)*sv*sv
+   do i=1,nsubx
+     k=(i-1)*nsuby+j
+     beta(k)=sv
+     amu(k)=sm
+     rtx(k)=(i-0.5)*dx
+     rtz(k)=(j-0.5)*dy
+   enddo
+ enddo
+! smoothing
+ do j=3,nsuby-2
+   ll=j+nsuby
+   amu(j)=0.2*sum(amu(ll-2:ll+2))
+ enddo
+!
+ vs_avg=0.0
+ do j=1,ncyp
+   sv=0.0
+   do k=j, ncyp
+     sv=sv+1./beta(k)
+   enddo
+   beta(j)=float(ncyp-j+1)/sv
+   vs_avg=vs_avg+beta(j)
+ enddo
+ do j=nsuby, ncyp+1, -1
+   sv=0.0
+   do k=ncyp+1, j
+     sv=sv+1./beta(k)
+   enddo
+   beta(j)=float(j-ncyp)/sv
+   vs_avg=vs_avg+beta(j)
+ enddo
+ do j=1,nsuby
+   do i=2,nsubx
+     k=(i-1)*nsuby+j
+     ll=k-nsuby
+     beta(k)=beta(ll)
+     amu(k) =amu(ll)
+   enddo
+ enddo
+ vs_avg=vs_avg/float(nsuby)
+!
+!  Setting the parameters for computing random Slip-Amplitude field
+!
+ select case(id_cl)
+ case(1)
+!The correlation length vs. magnitude (Mai and Beroza, 2002,JGR)
+   slip_clx =10.**(-2.5+Mw/2.)
+   slip_cly =10.**(-1.5+Mw/3.)
+ case(2)
+! The correlation length vs. magnitude (Grave,SCEC 2005)
+   slip_clx =10.**(-2.0+Mw/2.)
+   slip_cly =10.**(-2.0+Mw/2.)
+ case(3)
+!The correlation length vs. magnitude (Somerville, 1999,SRL)
+   slip_clx =10.**(-1.72+Mw/2.)
+   slip_cly =10.**(-1.93+Mw/2.)
+ case(4)
+! The correlation length vs. magnitude (Graves & Pitaka, 2010)
+    slip_clx =10.**(-1.7+Mw/2.)
+    slip_cly =10.**(-0.7+Mw/3.)
+ end select
+!
+!  correlation length less than 0.7* fault width/length
+!
+ slip_cly=amin1(slip_cly, 0.7*fwy)
+ slip_clx=amin1(slip_clx, 0.7*flx)
+! correlation length along strike shall be less than 2*c_width
+ slip_clx=amin1(slip_clx, amax1(2.0*slip_cly, flx/4.0))
+ if (flx < fwy) then
+   ttmp=slip_cly
+   slip_cly=slip_clx
+   slip_clx=ttmp
+endif
+!!! ? check the value for M>7.3 event.
+if(Mw >7.3) print *, Mw, slip_clx, slip_cly
+ sp1 = 2.0
+ sq1 = 5.0
+ slip_pw  = 2.0
+! hfrd=smoment*fc_main*fc_main
+ hfrd=smoment*fc_main_1*fc_main_2
+!
+! Setting the parameters for computing random Risetime filed
+!
+ rs_clx = amin1(slip_clx, 10.0)
+ rs_cly = amin1(slip_cly, 10.0)
+ rs_max=6.0
+!
+  rs_max= amax1(slip_clx,slip_cly)/2.5 ! asperity duration for 2.5 km/s rupture velocity
+!
+!   Somerville et al (1999), Chen Ji, 2020
+!   Note that the final risetime=rstm+pktm, so rstm = 0.84 risetime is assigned
+!
+ rstm_mean = 0.84*10**(0.5*Mw-3.34)
+ pktm_mean = 0.2 *rstm_mean
+! Using fc_main_2 to setup the initial value: risetime=1/fc_mean_2
+ rstm_mean = 0.84/fc_main_2
+ pktm_mean = 0.2*rstm_mean
+!
+ rp1= 3.0
+ rq1= 2.0
+ rs_pw  = 2.0
+!
+rs_pw = 0.54*slip_pw+0.675 ! using SAL12 relationship, Chen Ji, 2020
+!
+! Setting the parameters for computing random rupture-velocity filed
+!
+ rv_clx = amin1(slip_clx, 10.0)
+ rv_cly = amin1(slip_cly, 10.0)
+!
+ rv_pw = 2.0
+!
+ rv_pw = 0.23*slip_pw + 0.370   ! using SAL12 relationship, Chen Ji, 2020
+!
+! Setting the parameters for computing random peak time filter_field
+! Chen Ji, 2020
+!
+pk_pw = 0.29*slip_pw + 0.415 ! using SAL12 relationship, Chen Ji, 2020
+pk_max= 0.2*rs_max
+!
+! Setting the parameters for computing rupture velocity
+!
+ vp1=1.0
+ vq1=1.0
+ vmin_ratio = 0.6!0.5
+ vmax_ratio = 0.85!0.9
+ vs_avg=vs_avg*(vq1*vmin_ratio+vp1*vmax_ratio)/(vp1+vq1)
+ vs_avg=rv_avg/vs_avg
+ vmin_ratio = vmin_ratio*vs_avg
+ vmax_ratio = vmax_ratio*vs_avg
+ write(*,*) 'ratio= ',vs_avg
+!
+! Setting the cross-correlation coefficients
+! between slip-amplitude and rise-time, and
+! between slip-amplitude and rupture-velocity. (default: no correlation?)
+!
+ cr_sl_rs = 0.75 !0.62
+ cr_sl_vc = 0.0  !0.3
+! cr_sr_vc = 0.4 ! SAL10 relationship, Chen Ji, 2020
+ cr_pk_vc = -0.31
+!
+! Tapering the slip-amplitudes nearby the edage of fault, clockwise up-right-bottom-left
+!
+  taper= dx*dy
+! Top Side
+ nb=nb_taper_TRBL(1)
+ do j=1,nb
+   rat=(j-0.5)/nb
+   do i=1,nsubx
+     k=(i-1)*nsuby+j
+     taper(k)=taper(k)*rat
+   enddo
+ enddo
+! Bottom Side
+ nb=nb_taper_TRBL(3)
+ do j=1,nb
+   rat=(j-0.5)/nb
+   do i=1,nsubx
+     k=(i-1)*nsuby+(nsuby-j+1)
+     taper(k)=taper(k)*rat
+   enddo
+ enddo
+! Right
+ nb=nb_taper_TRBL(2)
+ do i=1,nb
+   rat=(i-0.5)/nb
+   do j=1,nsuby
+     k=(nsubx-i)*nsuby+j
+     taper(k)=taper(k)*rat
+   enddo
+ enddo
+! Left
+ nb=nb_taper_TRBL(4)
+ do i=1,nb
+   rat=(i-0.5)/nb
+   do j=1,nsuby
+     k=(i-1)*nsuby+j
+     taper(k)=taper(k)*rat
+   enddo
+ enddo
+!
+! i, j, ttmp: maximum on-fault hypocenter distance
+ i=max0(ncxp, nsubx-ncxp)
+ j=max0(ncyp, nsuby-ncyp)
+ ttmp=sqrt((i*dx)**2+(j*dy)**2)
+ vs_avg=rv_avg*2.0*vmin_ratio/(vmin_ratio+vmax_ratio)
+ dt=0.001
+ i=int(ttmp/vs_avg/dt+1.0)*10
+ ntime=1
+ do while(ntime<i)
+    ntime=ntime*2
+enddo
+! ntime: length of rise time function
+ df=1./(ntime*dt)
+ nphf=ntime/2
+ if(allocated(freq)) deallocate(freq)
+ allocate(freq(nphf))
+!
+ lnpt=int(log(real(ntime))/log(2.0)+0.1)
+ !nfe1=int(0.5*freq_max/df)+1
+ !nfe2=int(0.9*freq_max/df)
+ nfe1=int(1.1*freq_min/df)+1
+ nfe2=int(0.9*freq_max/df)+1
+ nbb=int(log(real(nfe1))/log(2.))
+ nee=int(log(real(nfe2))/log(2.))+1
+ ! In this study, we use 95% seismic moment as source duration criterion
+ ! A empirical correction of 0.78 is added (1-sqrt(0.05)~0.78),
+ t_percent=0.95
+ td_target=0.78/fc_main_1/3.14
+
+!
+! Using the acceleration spectrum as the target
+ io_dva=3
+!
+ write(*,*) "Finishing the setup of global variable"
+ write(*,*) "Magnitude = ",Mw
+ write(*,*) "expected double corner frequency = ", fc_main_1,fc_main_2
+ write(*,*) "expected Td_95= ",td_target
+ write(*,*) "expected average rise time =", rstm_mean
+ write(*,*) "ntime = ", ntime, " lnpt = ",lnpt
+ write(*,*) "nphf = ", nphf
+ write(*,*) "nbb = ", nbb, " nee = ",nee
+ write(*,*) "io_dva = ",io_dva
+!
+end subroutine mainfault
+!
+!======================================================================
+! procedure
+!     1. slip distribution: A k^-2 random field that has given comulative moment
+!     2. rise time:   A k^-1.75 random field with given rstm_mean
+!     A Loop of peaktime_mean
+!        peak time:  A k^-1 random field with peaktime_mean
+!        estimate peak-slip rate
+!        rupture velocity field
+!        generate the source spectrum
+!        change the peaktime_mean
+!     end-loop
+!     Note that here we assume that the peaktime << risetime
+!     Chen Ji, 2020
+!
+subroutine random_field(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr,err_spectra)
+ use sp_sub_f
+ use fdtim_2d
+ implicit NONE
+ integer, intent(INOUT):: idum1,idum2,idum3
+ integer, parameter:: itrmax=5
+ integer idum4
+ logical:: lloop,hloop
+ integer:: i,j,k,iset,niter,is_stress
+ real::ave_tr,ave_tp,ave_vr,err_spectra
+ real:: sum1,cmti,correct,cr0,cr1,cr2,csqt,cv0,cv1,cv2, &
+        vrup,er_syn,er_target,cr_sr,cr_sv,gasdev
+
+ real,dimension(nsum):: gasv1,gasv2,gasv3,gasv4,stdrop
+!
+! new parameters using GP approach for local rupture peturbation time (lrpt)
+!
+ real:: slip_mean, slip_max, slip_white,dt_scale
+! new parameters using Gusev approach
+ real:: rup_time_max,lrtp_clx,lrtp_cly,lrtp_pw,coef_lrtp
+ real:: rayl_sigma
+ real:: percent,td,tb,te
+!
+! Generating 4 Normal distributed white noise
+!
+ iset=0
+ do i=1,nsum
+   gasv1(i)=gasdev(idum1,iset)
+ enddo
+ ! write(*,*) 'DEBUG gasv1(1:5)=', gasv1(1:5)
+ iset=0
+ do i=1,nsum
+   gasv2(i)=gasdev(idum2,iset)
+ enddo
+ ! write(*,*) 'DEBUG gasv2(1:5)=', gasv2(1:5)
+ iset=0
+ do i=1,nsum
+   gasv3(i)=gasdev(idum3,iset)
+ enddo
+ ! write(*,*) 'DEBUG gasv3(1:5)=', gasv3(1:5)
+ iset=0
+ idum4=idum1+nsum
+ do i=1,nsum
+   gasv4(i)=gasdev(idum4,iset)
+ enddo
+ ! write(*,*) 'DEBUG gasv4(1:5)=', gasv4(1:5)
+! 1. slip distribution
+!
+ slip=gasv1
+ call filter_field(slip,slip_clx,slip_cly,slip_pw,dx,dy,nsubx,nsuby)
+! mapping to the desired distributions using NORTA technique
+! by keeping cumulative probability same, Liu et al. (2006)
+! slip amplitude following Cauchy distribution
+ call random_slip_am_C(slip,nsum)
+!
+ stdrop=slip*taper    ! unit is meter
+!
+ slip=slip*amu*taper
+ correct=smoment/sum(slip(1:nsum))
+ slip=slip*correct   ! Note: now the unit of slip is not meter.
+!
+! Stress
+! stdrop=slip
+!
+!call stress_drop(stdrop,dx,dy,nsubx,nsuby)
+!call coherent(cr_sr,nsum,slip,stdrop)
+!write(*,*) 'correlation between the fault slip and static stress drop = ',cr_sr
+!
+! 2. rise time distribution
+!
+ cr0=cr_sl_rs
+ cr1=0.0
+ cr2=1.0
+ if(cr_sl_rs < 0.0) then
+   cr1=-1.0
+   cr2=0.0
+ endif
+ niter=0
+ lloop=.true.
+ do while(lloop)
+   niter=niter+1
+   csqt=sqrt(1.-cr0*cr0)
+   do i=1,nsum
+     rstm(i)=abs(cr0)*gasv1(i)+csqt*gasv2(i)
+   enddo
+   call filter_field(rstm,rs_clx,rs_cly,rs_pw,dx,dy,nsubx,nsuby)
+   call random_rise_tm(rstm,nsum,rs_max,rp1,rq1)
+! Use GP approach in rise time
+  do i=1,nsuby
+    do j=1,nsubx
+      k=(j-1)*nsuby+i
+      if(depth_source(i).lt.5.0)then
+!      rstm(k)=rstm(k)*2.0
+      endif
+    enddo
+  enddo
+!
+   correct=rstm_mean/(sum(rstm(1:nsum))/nsum)
+   rstm=rstm*correct
+   call coherent(cr_sr,nsum,slip,rstm)
+   write(*,*) 'cross rise, slip-amp',cr_sr,cr0,cr_sl_rs
+!
+   if(abs(cr_sr-cr_sl_rs) < 0.01 .or. niter > itrmax) lloop=.false.
+   if(cr_sr > cr_sl_rs) then
+     cr2=cr0
+   else
+     cr1=cr0
+   endif
+   cr0=0.5*(cr2+cr1)
+ enddo
+ call coherent(cr_sr,nsum,slip,rstm)
+ write(*,*) 'correlation between slip and rise time = ',cr_sr
+ call coherent(cr_sr,nsum,rstm,stdrop)
+ write(*,*) 'correlation between stress drop and rise time = ',cr_sr
+!
+! 3. distribution of peak time
+! Using SAJ13, peak time has k^~-1 spatial distribution
+!
+!pktm_mean=0.2*rstm_mean
+write(*,*)"creating k^-1 peak time distribution with mean of ", pktm_mean,pk_pw
+! SAL10: negligible correlation between fault slip and peak time
+! Using a new gaussian vector
+pktm=gasv4
+call filter_field(pktm,rs_clx,rs_cly,pk_pw,dx,dy,nsubx,nsuby)
+!call random_rise_tm(pktm,nsum,pk_max,rp1,rq1)
+call random_slip_am_C(pktm,nsum)
+! normalization
+correct=pktm_mean/(sum(pktm,1)/nsum)
+pktm=pktm*correct
+call coherent(cr_sv,nsum,pktm,slip)
+!
+write(*,*)"correct = ",correct
+write(*,*)"correlation between pktm and slip= ", cr_sv
+call coherent(cr_sv,nsum,pktm,rstm)
+write(*,*)"correlation between pktm and rise time= ", cr_sv
+!
+! rupture initiation time
+!
+ave_vr=0.7
+niter=0
+lloop=.true.
+do while(lloop)
+  niter=niter+1
+!  do i=1,nsum
+  do i=1,nsuby
+    do j=1,nsubx
+      k=(j-1)*nsuby+i
+      if(depth_source(i).gt.5.0)then
+        vrup=ave_vr*beta(k)
+      else
+        vrup=ave_vr*beta(k)*0.7
+      endif
+      rpvel(k)=vrup
+      rptm(k)=1.0/vrup
+    enddo
+  enddo
+  call rup_tim_2d(nsum,nsuby,nsubx,dx,dy,rptm)
+  rup_time_max=maxval(rptm)
+  write(*,*)"maximum rupture time =",rup_time_max
+!  id_lrtp=1
+!
+! rupture time perturbation
+!
+! Hisada&Gusev approach 1. GP approach = 2
+! Using GP approach, will lead to about 10% increase in rise time.
+! Chen Ji, 2020
+!
+  select case(id_lrtp)
+  case(0)
+  ! spatially uncorrelated but
+    coef_lrtp=0.5
+    lrtp=gasv1
+    rayl_sigma=rstm_mean/2.0
+    call random_rayleigh(lrtp,nsum,rayl_sigma)
+    call coherent(cr_sv,nsum,lrtp,slip)
+    write(*,*)" case 0 correlation between lrtp and slip= ", cr_sv
+    do i=1,nsum
+      lrtp(i)=lrtp(i)*((rptm(i)/rup_time_max)**coef_lrtp)
+    enddo
+    correct=rstm_mean/(sum(lrtp)/nsum)
+    lrtp=lrtp*correct
+  case(1)
+  ! Guesv didn't mention the correlation length, here we use a half of
+  ! slip pulse as correlation length, following Bernard (1994). We also
+  ! assume the rupture velocity is 2.5 km/sec.
+  !
+    lrtp_clx=rstm_mean*2.5
+    lrtp_cly=lrtp_clx
+    lrtp_pw=2.0
+    coef_lrtp=0.25
+    rayl_sigma=rstm_mean/2.0
+  !
+    lrtp=gasv3
+    call filter_field(lrtp,lrtp_clx,lrtp_cly,lrtp_pw,dx,dy,nsubx,nsuby)
+    call random_rayleigh(lrtp,nsum,rayl_sigma)
+    write(*,*)"maximum and minimum ",maxval(lrtp),minval(lrtp),rayl_sigma
+    call coherent(cr_sv,nsum,lrtp,slip)
+    write(*,*)"Gusev correlation between lrtp and slip= ", cr_sv
+    write(*,*)"maximum lrtp = ",maxval(lrtp)
+    do i=1,nsum
+      lrtp(i)=lrtp(i)*((rptm(i)/rup_time_max)**coef_lrtp)
+    enddo
+    correct=0.5*rstm_mean/(sum(lrtp)/nsum)
+    lrtp=lrtp*correct
+    write(*,*)"maximum lrtp = ",maxval(lrtp), correct, rstm_mean
+  case(2)
+  !
+  ! GP approach
+  ! GP's approach is deterministic
+  !
+    slip_mean=sum(slip)/nsum
+    slip_max=maxval(slip)
+    slip_white=0.05*slip_mean
+    dt_scale=1.8e-9*((Moment_o*1.0e7)**(1.0/3.0))
+    dt_scale=log(slip_max/slip_mean)*dt_scale*0.5
+    coef_lrtp=0.25
+    do i=1,nsum
+      lrtp(i)=-dt_scale*(log(slip(i)/slip_mean))*((rptm(i)/rup_time_max)**coef_lrtp)
+    end do
+    call coherent(cr_sv,nsum,lrtp,slip)
+    write(*,*)"GP correlation between lrtp and slip= ", cr_sv
+  end select
+
+  do i=1,nsum
+    rptm(i)=rptm(i)+lrtp(i)
+    if(rptm(i).lt.0.0)rptm(i)=0.0
+  enddo
+
+  percent=t_percent
+  call stf_duration(percent,td,tb,te)
+  write(*,*)"duration =",percent,td,tb,te
+  if(abs(td/td_target-1.0)<0.025 .or. niter > itrmax) lloop=.false.
+  write(*,*)"Before average rupture velocity = ", td, td_target, ave_vr
+  ave_vr=ave_vr*td/td_target
+  write(*,*)"After average rupture velocity = ", td, td_target, ave_vr
+enddo
+
+! As high frequency radiation is more sensitive to rise time,
+call misfit_ratio(smoment,fc_main_1,fc_main_2,correct,err_spectra)
+write(*,*) 'the misfit in ratio ', correct, (sum(rstm,1)/nsum),err_spectra
+if(correct.lt.0.8)then
+  do i=1,nsum
+    rstm(i)=rstm(i)*((correct/0.8)**1.4)
+    pktm(i)=pktm(i)*((correct/0.8)**1.4)
+  enddo
+  write(*,*) 'the misfit in ratio step-1', correct, (sum(rstm,1)/nsum)
+endif
+if(correct.gt.1.25)then
+  do i=1,nsum
+    rstm(i)=rstm(i)*((correct/1.25)**1.4)
+    pktm(i)=pktm(i)*((correct/1.25)**1.4)
+  enddo
+  write(*,*) 'the misfit in ratio step-1', correct, (sum(rstm,1)/nsum)
+endif
+niter=0
+hloop=.true.
+do while(hloop)
+  call misfit_ratio(smoment,fc_main_1,fc_main_2,correct,err_spectra)
+  write(*,*) 'the misfit in ratio step-2', correct, (sum(pktm,1)/nsum),err_spectra
+  if(abs(correct-1.) < 0.03 .or. niter > itrmax) then
+    hloop=.false.
+  else
+    pktm=pktm*(correct**2.5)
+  endif
+  niter=niter+1
+enddo
+
+! check the quality of solution
+write(*,*)"re-evaluate Quality of selected source model"
+call misfit_ratio(smoment,fc_main_1,fc_main_2,correct,err_spectra)
+write(*,*)"Misfit_ratio = ", correct,err_spectra
+call coherent(cr_sv,nsum,rstm,pktm)
+write(*,*) 'cross-correlation between risetime(y) and peak time =',cr_sv
+do i=1,nsum
+  rstm(i)=rstm(i)+pktm(i)
+end do
+ave_tr=sum(rstm)/nsum
+ave_tp=sum(pktm)/nsum
+call coherent(cr_sv,nsum,rstm,slip)
+write(*,*) 'cross-correlation between risetime and slip =',cr_sv,'target =',cr_sl_rs
+call coherent(cr_sv,nsum,rstm,pktm)
+write(*,*) 'cross-correlation between risetime and peak time =',cr_sv
+do i=1,nsum
+  pktm(i)=pktm(i)/rstm(i)
+end do
+call stf_synth_output(smoment,fc_main_1,fc_main_2)
+!
+! scale the unit of seismic moment to N-m
+  slip=slip*1.0e+15
+!
+! Perturbate the rake dip, and azimuth angle
+!
+  iset=0
+  do i=1,nsum
+    rake_prt(i)=gasdev(idum2,iset)
+  enddo
+  call filter_field(rake_prt,slip_clx,slip_cly,2.0,dx,dy,nsubx,nsuby)
+  call random_rake(rake_prt,nsum)
+
+  iset=0
+  do i=1,nsum
+    dip_prt(i)=gasdev(idum2,iset)
+  enddo
+  call filter_field(dip_prt,slip_clx,slip_cly,2.0,dx,dy,nsubx,nsuby)
+  call random_rake(dip_prt,nsum)
+
+  iset=0
+  do i=1,nsum
+    amz_prt(i)=gasdev(idum2,iset)
+  enddo
+  call filter_field(amz_prt,slip_clx,slip_cly,1.5,dx,dy,nsubx,nsuby)
+  call random_rake(amz_prt,nsum)
+
+end subroutine random_field
+!
+!======================================================================
+! origin name: random_rup_tim
+!
+subroutine rup_tim_2d(nsum,nsuby,nsubx,dx,dy,rptm)
+ use fdtim_2d
+ implicit NONE
+ integer, intent(IN):: nsum,nsuby,nsubx
+ real:: dx,dy,rptm(nsum)
+ integer:: i,j,k,jx,jz,jxz,jxzx
+ real:: rx,rz,rz1
+ real, dimension(nx_2d, nz_2d):: rtm_2d,slow
+!
+! as input, rptm is local slowness of rupture velocity
+! Chen Ji, 2020
+! do k=1,nsum
+!   rptm(k)=sqrt((rtx(k)-cxp)**2+(rtz(k)-cyp)**2)*rptm(k)
+! enddo
+! return
+!
+ do k=1,nz_2d
+   rz=float(k-1)*grid_2d/dy
+   jz=min0(int(rz)+1,nsuby-1)
+   rz=amax1(jz-rz, 0.0)
+   rz1=1.-rz
+   do i=1,nx_2d
+     rx=float(i-1)*grid_2d/dx
+     jx=min0(int(rx)+1, nsubx-1)
+     rx=amax1(jx-rx, 0.0)
+     jxz=(jx-1)*nsuby+jz
+     jxzx=jxz+nsuby
+     slow(i,k)=rx*(rz*rptm(jxz) +rz1*rptm(jxz+1))+ &
+          (1.-rx)*(rz*rptm(jxzx)+rz1*rptm(jxzx+1))
+   enddo
+ enddo
+ call XZPTIM(rtm_2d,slow,nx_2d,nx_2d,nz_2d,grid_2d, &
+             cxp,cyp,rptm,rtx,rtz,nsum)
+
+end subroutine rup_tim_2d
+!
+!
+!======================================================================
+!
+subroutine random_slip_am_C(xp,n)
+!  a=a0*averg
+!  b=d1*averg
+!  xmax=a1*averg
+!  af0=atan(-a/b)
+!  af1=atan((xmax-a)/b)
+!  pdf=1./((af1-af0)*b)/(1.+((x-a)/b)**2)
+!
+ implicit NONE
+ real, parameter:: a0 = 0.30, a1 = 3.5, averg=1.0
+ integer:: n,i
+ real, dimension(n):: xp
+ real:: af0,af1,d1,daf,r
+
+ call gasprb(xp,n)
+ call coef_slip_am(a0,a1,af0,af1,d1)
+ daf=af1-af0
+ do i=1,n
+   r=tan(af0+xp(i)*daf)
+   xp(i)=(a0+d1*r)*averg
+ enddo
+
+end subroutine random_slip_am_C
+!
+!======================================================================
+!
+subroutine coef_slip_am(a0,a1,af0,af1,d1)
+ implicit NONE
+ real, parameter:: err=1.e-5
+ real:: a0,a1,af0,af1,d1,x0,x1,ff
+ logical:: lloop
+ x0=0.01
+ x1=a1*4
+ lloop=.true.
+ do while(lloop)
+   d1=0.5*(x0+x1)
+   af0=-atan(a0/d1)
+   af1= atan((a1-a0)/d1)
+! Fitting Average
+   ff=-1.0+a0+0.5*d1/(af1-af0)*alog(((a1-a0)**2+d1**2)/(a0**2+d1**2))
+!
+!   Fitting Varation
+!   ff=-1.0+a1*d1/(af1-af0)+2.*a0*(a0+0.5*d1/(af1-af0)* &
+!       alog(((a1-a0)**2+d1**2)/(a0**2+d1**2)))-(a0*a0+d1*d1)
+!
+   if(abs(ff) < err) lloop=.false.
+   if(ff > 0.0) then
+     x1=d1
+   else
+     x0=d1
+   endif
+ enddo
+
+end subroutine coef_slip_am
+!
+!======================================================================
+!
+subroutine random_slip_am_B(xp,n,p,q)
+!  beta distribution
+!  pdf(x)=coef*(x-x0)**c1*(x1-x)**c2, x0 <= x <= x1 <=1
+!  pdf(x0)=0.0
+!  pdf(x1)=1.0
+ implicit NONE
+ integer, parameter:: nseg =10000
+ integer n,i,j0,j1,jj
+ real:: xp(n),p,q
+ real:: pacul(nseg),dx,xi,x0,x1,c1,c2,pr
+ x0=0.0
+ x1=1.0
+ call gasprb(xp,n)
+ x0=0.0
+ x1=1.0
+ c1=p-1
+ c2=q-1
+ dx=(x1-x0)/(nseg-1.)
+ pacul(1)=0.0
+ do i=2,nseg
+   xi=x0+(i-1.5)*dx
+   pacul(i)=pacul(i-1)+(xi-x0)**c1*(x1-xi)**c2
+ enddo
+ do i=2,nseg
+   pacul(i)=pacul(i)/pacul(nseg)
+ enddo
+
+ do i=1,n
+   pr=xp(i)
+   j0=1
+   j1=nseg
+   jj=ifix(nseg*pr-pr)+1
+   do while(j1-j0 > 1)
+     if(pr > pacul(jj) ) then
+       j0=jj
+     else
+       j1=jj
+     endif
+     jj=(j0+j1)/2
+   enddo
+! linearly interpolating between j0 and j0+1
+   xp(i)=x0+dx*(j0-1.0+(pr-pacul(j0))/(pacul(j0+1)-pacul(j0)))
+ enddo
+
+end subroutine random_slip_am_B
+!
+!==========================  Rise Time  =============================
+!
+subroutine random_rise_tm(xp,n,rs_max,p,q)
+!  P(x0)=0.0
+!  P(x1)=1.0
+!  pdf(rs)=1./(x1-x0)**(p+q-1)/beta(p,q)*(x-x0)**(p-1)*(x1-x)**(q-1)
+!
+ implicit NONE
+ integer, parameter:: nseg =10000
+ integer:: n,i,j0,j1,jj
+ real:: p,q,rs_max,xp(n)
+ real:: pacul(nseg),dx,xi,x0,x1,c1,c2,pr,cff
+
+ call gasprb(xp,n)
+ x0=1.0
+ x1=rs_max
+ c1=p-1
+ c2=q-1
+ cff=1.-rs_max**p
+
+ dx=(x1-x0)/(nseg-1.)
+ pacul(1)=0.0
+ do i=2,nseg
+   xi=x0+(i-1.5)*dx
+   pacul(i)=pacul(i-1)+(xi-x0)**c1*(x1-xi)**c2
+ enddo
+ do i=2,nseg
+   pacul(i)=pacul(i)/pacul(nseg)
+ enddo
+!
+ do i=1,n
+!   pr=1.-xp(i)
+   pr=xp(i)
+   j0=1
+   j1=nseg
+   jj=ifix(nseg*pr-pr)+1
+   do while(j1-j0 .gt.1)
+     if(pr > pacul(jj) ) then
+       j0=jj
+     else
+       j1=jj
+     endif
+     jj=(j0+j1)/2
+   enddo
+! linearly interpolating between j0 and j1
+   xp(i)=x0+dx*(j0-1.0+(pr-pacul(j0))/(pacul(j0+1)-pacul(j0)))
+ enddo
+!
+! do i=1,n
+!   xp(i)=1./xp(i)
+! enddo
+
+end subroutine random_rise_tm
+!
+!========================== random_rayleigh ====================
+! Note: for rayleigh distribution, mode is sigma, 95% of values are less than 2.5*sigma.
+! Chen Ji, 2020
+subroutine random_rayleigh(xp,n,sigma)
+  implicit NONE
+  integer:: n,i
+  real:: sigma,xp(n),pr
+  real:: irayl
+
+  call gasprb(xp,n)
+  do i=1,n
+    pr=xp(i)
+    xp(i)=irayl(pr,sigma)
+  end do
+end subroutine random_rayleigh
+!
+!==========================  Rake  =============================
+!
+subroutine random_rake(xp,n)
+ implicit NONE
+ integer, parameter:: nseg =10000
+ integer:: n,i
+ real:: xp(n), pacul(nseg)
+
+ call gasprb(xp,n)
+ do i=1,n
+   xp(i)=2.*xp(i)-1.0
+ enddo
+
+end subroutine random_rake
+!
+!======================================================================
+!
+subroutine random_rup_vel(xp,n,x0,x1,p,q)
+!  beta : local S-wave velocity
+!  rup_vel=beta*x
+!  vmin=x0*beta
+!  vmax=x1*beta
+!  pdf(x)=coef*(x-x0)**c1*(x1-x)**c2, x0 <= x <= x1 <=1
+!  pdf(x0)=0.0
+!  pdf(x1)=1.0
+ implicit NONE
+ integer, parameter:: nseg =10000
+ integer:: n,i,j0,j1,jj
+ real:: xp(n),x0,x1,p,q
+ real:: pacul(nseg),c1,c2,dx,xi,pr
+
+ call gasprb(xp,n)
+ c1=p-1
+ c2=q-1
+ dx=(x1-x0)/(nseg-1.)
+ pacul(1)=0.0
+ do i=2,nseg
+   xi=x0+(i-1.5)*dx
+   pacul(i)=pacul(i-1)+(xi-x0)**c1*(x1-xi)**c2
+ enddo
+ do i=2,nseg
+   pacul(i)=pacul(i)/pacul(nseg)
+ enddo
+
+ do i=1,n
+   pr=xp(i)
+   j0=1
+   j1=nseg
+   jj=ifix(nseg*pr-pr)+1
+   do while(j1-j0 > 1)
+     if(pr .gt. pacul(jj) ) then
+       j0=jj
+     else
+       j1=jj
+     endif
+     jj=(j0+j1)/2
+   enddo
+! linearly interpolating between j0 and j0+1
+   xp(i)=x0+dx*(j0-1.0+(pr-pacul(j0))/(pacul(j0+1)-pacul(j0)))
+ enddo
+
+end subroutine random_rup_vel
+!
+!======================================================================
+!
+subroutine filter_field(source,clx,cly,pw2,dx,dy,nx,ny)
+ implicit NONE
+ integer,intent(IN):: nx,ny
+ real, intent(IN):: clx,cly,pw2,dx,dy
+ real source(nx*ny),param(nx*ny),speq(nx*2)
+ integer:: nxy,nhfx,nhfy,ie,ke1,ke2,kr,k1,k2,j1,j2,i2,i,j,k,ix0,jy0
+ real:: dwkx,dwky,cff,sq2,pw,wkx,wky,filter,ru1,ru2,rv1,rv2,cf
+
+ nxy=nx*ny
+ nhfx=nx/2
+ nhfy=ny/2
+! df
+ dwkx=clx/(nx*dx)
+ dwky=cly/(ny*dy)
+ cff=0.0
+ sq2=sqrt(1.0+cff)
+ pw=0.5*pw2
+ kr=0
+!-----zero wavenumber kx
+ i=1
+ wkx=((i-1)*dwkx)**2
+ do j=2,nhfy
+   wky=((j-1)*dwky)**2
+   filter=1./sqrt(1.+(wkx+wky)**pw2)
+!   filter=1./(1.+(wkx+wky))**pw
+   k1=2*((i-1)*nhfy+j)-1
+   k2=k1+1
+   param(k1)=-abs(source(kr+1)*filter/sq2)
+   param(k2)=cff*source(kr+2)*filter/sq2
+   kr=kr+2
+ enddo
+!-----maximum wavenumber kx
+ i=1+nhfx
+ wkx=((i-1)*dwkx)**2
+ do j=2,nhfy
+   wky=((j-1)*dwky)**2
+   filter=1./sqrt(1.+(wkx+wky)**pw2)
+!   filter=1./(1.+(wkx+wky))**pw
+   k1=2*((i-1)*nhfy+j)-1
+   k2=k1+1
+   param(k1)=-abs(source(kr+1)*filter/sq2)
+   param(k2)=cff*source(kr+2)*filter/sq2
+   kr=kr+2
+ enddo
+!----zero wavenumber ky
+ j=1
+ wky=((j-1)*dwky)**2
+ do i=2,nhfx
+   wkx=((i-1)*dwkx)**2
+   filter=1./sqrt(1.+(wkx+wky)**pw2)
+!   filter=1./(1.+(wkx+wky))**pw
+   k1=2*((i-1)*nhfy+j)-1
+   k2=k1+1
+   param(k1)=-abs(source(kr+1)*filter/sq2)
+   param(k2)=cff*source(kr+2)*filter/sq2
+   kr=kr+2
+   ie=nx-i+2
+   ke1=2*((ie-1)*nhfy+j)-1
+   ke2=ke1+1
+   param(ke1)= param(k1)
+   param(ke2)=-param(k2)
+ enddo
+!----maximum wavenumber ky
+ j=nhfy+1
+ wky=((j-1)*dwky)**2
+ do i=2,nhfx
+   wkx=((i-1)*dwkx)**2
+   filter=1./sqrt(1.+(wkx+wky)**pw2)
+!   filter=1./(1.+(wkx+wky))**pw
+   k1=2*i-1
+   k2=k1+1
+   speq(k1)=-abs(source(kr+1)*filter/sq2)
+   speq(k2)=cff*source(kr+2)*filter/sq2
+   kr=kr+2
+   ie=nx-i+2
+   ke1=2*ie-1
+   ke2=ke1+1
+   speq(ke1)= speq(k1)
+   speq(ke2)=-speq(k2)
+ enddo
+!----
+ i=1
+ j=1
+ param(1)=0.0
+ param(2)=0.0
+ kr=kr+1
+!----
+ i=nhfx+1
+ j=1
+ wkx=((i-1)*dwkx)**2
+ wky=((j-1)*dwky)**2
+ filter=1./sqrt(1.+(wkx+wky)**pw2)
+! filter=1./(1.+(wkx+wky))**pw
+ k1=2*((i-1)*nhfy+j)-1
+ k2=k1+1
+ param(k1)=-abs(source(kr+1)*filter)
+ param(k2)=0.0
+ kr=kr+1
+!----
+ i=1
+ j=nhfy+1
+ wkx=((i-1)*dwkx)**2
+ wky=((j-1)*dwky)**2
+ filter=1./sqrt(1.+(wkx+wky)**pw2)
+! filter=1./(1.+(wkx+wky))**pw
+ k1=2*((i-1)*nhfy+j)-1
+ k2=k1+1
+ speq(1)=-abs(source(kr+1)*filter)
+ speq(2)=0.0
+ kr=kr+1
+!----
+ i=nhfx+1
+ j=nhfy+1
+ wkx=((i-1)*dwkx)**2
+ wky=((j-1)*dwky)**2
+ filter=1./sqrt(1.+(wkx+wky)**pw2)
+! filter=1./(1.+(wkx+wky))**pw
+ speq(2*i-1)=source(kr+1)*filter
+ speq(2*i)  =0.0
+ kr=kr+1
+!----center
+ do i=2,nhfx
+ do j=2,nhfy
+   wkx=((i-1)*dwkx)**2
+   wky=((j-1)*dwky)**2
+   filter=1./sqrt(1.+(wkx+wky)**pw2)
+!   filter=1./(1.+(wkx+wky))**pw
+   ru1=source(kr+1)
+   rv1=source(kr+2)
+   ru2=source(kr+3)
+   rv2=source(kr+4)
+   k1=2*((i-1)*nhfy+j)-1
+   k2=k1+1
+   param(k1)=(ru1-ru2)*filter/2.0
+   param(k2)=(rv1+rv2)*filter/2.0
+   kr=kr+4
+   ie=nx-i+2
+   ke1=2*((ie-1)*nhfy+j)-1
+   ke2=ke1+1
+   param(ke1)=(ru1+ru2)*filter/2.0
+   param(ke2)=(rv1-rv2)*filter/2.0
+ enddo
+ enddo
+ call rlft3(param,speq,ny,nx,1,-1)
+
+ ix0=1
+ jy0=1
+ cf=2./float(nxy)
+ k=0
+ i2=nx+ix0-1
+ j2=ny+jy0-1
+ do i=ix0,i2
+ do j=jy0,j2
+   k=k+1
+   source(k)=param((i-1)*ny+j)*cf
+ enddo
+ enddo
+
+end subroutine filter_field
+!
+!======================================================================
+!
+subroutine stress_drop(source,dx,dy,nx,ny)
+ implicit NONE
+ integer, intent(IN)::nx,ny
+ real, intent(IN):: dx,dy
+ real:: source(nx*ny),param(nx*ny),speq(nx*2)
+ real:: dwkx,dwky,wkx,wky,wkxy,cf
+ integer:: nxy,nhfx,nhfy,ie,ke1,ke2,k1,k2,i,j
+
+ nxy=nx*ny
+ nhfx=nx/2
+ nhfy=ny/2
+ dwkx=1.0/(nx*dx)
+ dwky=1.0/(ny*dy)
+ call rlft3(source,speq,ny,nx,1,+1)
+!----
+ j=nhfy+1
+ wky=((j-1)*dwky)**2
+ do i=1,nhfx+1
+   wkx=((i-1)*dwkx)**2
+   wkxy=sqrt(wkx+wky)
+   k1=2*i-1
+   k2=k1+1
+   speq(k1)=speq(k1)*wkxy
+   speq(k2)=speq(k2)*wkxy
+   if(i > 1 .and. i <= nhfx) then
+     ie=nx-i+2
+     ke1=2*ie-1
+     ke2=ke1+1
+     speq(ke1)= speq(k1)
+     speq(ke2)=-speq(k2)
+   endif
+ enddo
+!----
+ do i=1,nhfx+1
+ do j=1,nhfy
+   wkx=((i-1)*dwkx)**2
+   wky=((j-1)*dwky)**2
+   wkxy=sqrt(wkx+wky)
+   k1=2*((i-1)*nhfy+j)-1
+   k2=k1+1
+   param(k1)=source(k1)*wkxy
+   param(k2)=source(k2)*wkxy
+   if(i.gt.1 .and. i.le.nhfx) then
+     ie=nx-i+2
+     ke1=2*((ie-1)*nhfy+j)-1
+     ke2=ke1+1
+     param(ke1)=source(ke1)*wkxy
+     param(ke2)=source(ke2)*wkxy
+   endif
+ enddo
+ enddo
+ call rlft3(param,speq,ny,nx,1,-1)
+
+ cf=2./float(nxy)
+ do i=1,nxy
+   source(i)=param(i)*cf
+ enddo
+
+end subroutine stress_drop
+!
+!=====================================================================
+! The name of subroutine is misleading.
+! What it calculates is the intergration of acceleration level from 0.5 to 0.9 freq_max
+! in other word, keep a_hf between source model and stress parameter
+!
+! Chen Ji, 2020
+
+subroutine Rd_energy_brune(energy,fc)
+ use time_freq
+ implicit none
+ integer::  i,j
+ real:: fc,energy
+ real:: moment_rate(nphf),density,vs,coef,pi
+
+ do i=1,nphf
+   freq(i)=i*df
+   moment_rate(i)=1./(1.+(freq(i)/fc)**2)
+ enddo
+
+ density=1.0
+ vs=1.0
+ pi=3.1415926
+ coef=8.*pi/(10.*pi*density*vs**5)*df
+ energy=0.0
+ do j=nfe1,nfe2
+!   energy=energy+(freq(j)*moment_rate(j))**2
+!   energy=energy+alog(moment_rate(j)*freq(j)**2)
+   energy=energy+(moment_rate(j)*freq(j)**2)
+ enddo
+! energy=exp(energy/float(nfe2-nfe1+1))*coef
+ energy=energy*coef
+
+end subroutine Rd_energy_brune
+!
+!=====================================================================
+!
+subroutine Rd_energy_synth(energy,rmt,fc)
+ use time_freq
+ implicit none
+ integer:: i,j
+ real:: rmt,fc,energy
+ real:: svf(ntime),moment_rate(nphf)
+ real:: density,brune,vs,coef,pi,tim,dtmt
+
+ !svf=0.0
+ call sum_point_svf(svf)
+ open(19,file='calsvf_tim.dat',status='replace')
+ write(19,*) ntime
+ do i=1,ntime
+    tim=(i-1)*dt
+    write(19,*) tim,svf(i)/rmt
+ enddo
+ close(19)
+!
+ call realft(svf,ntime,-1)
+ dtmt=dt/rmt
+ do i=1,ntime
+   svf(i)=svf(i)*dtmt
+ enddo
+ do i=1,nphf-1
+   moment_rate(i)=sqrt(svf(2*i+1)**2+svf(2*i+2)**2)
+ enddo
+ moment_rate(nphf)=svf(2)
+
+ open(19,file='calsvf.dat')
+ write(19,*) nphf
+ do i=1,nphf
+   brune=1./(1.+(freq(i)/fc)**2)
+   write(19,*) freq(i),moment_rate(i),brune
+ end do
+ close(19)
+!
+ density=1.0
+ vs=1.0
+ pi=3.1415926
+ coef=8.*pi/(10.*pi*density*vs**5)*df
+ energy=0.0
+ do j=nfe1,nfe2
+!   energy=energy+(freq(j)*moment_rate(j))**2
+!   energy=energy+alog(moment_rate(j)*freq(j)**2)
+   energy=energy+(moment_rate(j)*freq(j)**2)
+ enddo
+ energy=energy*coef
+
+end subroutine Rd_energy_synth
+!
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!
+! The name of subroutine is misleading.
+! What it calculates is the intergration of acceleration level from 0.5 to 0.9 freq_max
+! in other word, keep a_hf between source model and stress parameter
+!
+! Chen Ji, 2020
+
+subroutine Rd_energy_dcf(energy,fc1,fc2)
+ use time_freq
+ implicit none
+ integer::  i,j
+ real:: fc1,fc2,energy
+ real:: moment_rate(nphf),density,vs,coef,pi
+
+ do i=1,nphf
+   freq(i)=i*df
+   moment_rate(i)=1./((1.+(freq(i)/fc1)**4.0)**0.25)/((1.+(freq(i)/fc2)**4.0)**0.25)
+ enddo
+
+ density=1.0
+ vs=1.0
+ pi=3.1415926
+ coef=8.*pi/(10.*pi*density*vs**5)*df
+ energy=0.0
+ do j=nfe1,nfe2
+!   energy=energy+(freq(j)*moment_rate(j))**2
+!   energy=energy+alog(moment_rate(j)*freq(j)**2)
+   energy=energy+(moment_rate(j)*freq(j)**2)
+ enddo
+! energy=exp(energy/float(nfe2-nfe1+1))*coef
+ energy=energy*coef
+
+end subroutine Rd_energy_dcf
+!
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!
+!
+!=====================================================================
+!
+subroutine Rd_energy_synth_dcf(energy,rmt,fc1,fc2)
+ use time_freq
+ implicit none
+ integer:: i,j
+ real:: rmt,fc1,fc2,energy
+ real:: svf(ntime),moment_rate(nphf)
+ real:: density,dcf,vs,coef,pi,tim,dtmt
+
+ !svf=0.0
+ call sum_point_svf(svf)
+ open(19,file='calsvf_tim.dat',status='replace')
+ write(19,*) ntime
+ do i=1,ntime
+    tim=(i-1)*dt
+    write(19,*) tim,svf(i)/rmt
+ enddo
+ close(19)
+!
+ call realft(svf,ntime,-1)
+ dtmt=dt/rmt
+ do i=1,ntime
+   svf(i)=svf(i)*dtmt
+ enddo
+ do i=1,nphf-1
+   moment_rate(i)=sqrt(svf(2*i+1)**2+svf(2*i+2)**2)
+ enddo
+ moment_rate(nphf)=svf(2)
+
+ open(19,file='calsvf.dat')
+ write(19,*) nphf
+ do i=1,nphf
+!    brune=1./(1.+(freq(i)/fc)**2)
+    dcf=1./((1.+(freq(i)/fc1)**4.0)**0.25)/((1.+(freq(i)/fc2)**4.0)**0.25)
+   write(19,*) freq(i),moment_rate(i),dcf
+ end do
+ close(19)
+!
+ density=1.0
+ vs=1.0
+ pi=3.1415926
+ coef=8.*pi/(10.*pi*density*vs**5)*df
+ energy=0.0
+ do j=nfe1,nfe2
+!   energy=energy+(freq(j)*moment_rate(j))**2
+!   energy=energy+alog(moment_rate(j)*freq(j)**2)
+   energy=energy+(moment_rate(j)*freq(j)**2)
+ enddo
+ energy=energy*coef
+
+end subroutine Rd_energy_synth_dcf
+!
+!======================================================================
+!
+subroutine coherent(cr_srv,nsub,slip,rstm)
+ implicit NONE
+ integer, intent(IN):: nsub
+ real, dimension(nsub), intent(IN):: slip, rstm
+ real, intent(OUT):: cr_srv
+ integer:: i
+ real:: avg_s,avg_r,s2,r2,sr,ds,dr
+!
+ avg_s=0.0
+ avg_r=0.0
+ do i=1,nsub
+   avg_s=avg_s+slip(i)
+   avg_r=avg_r+rstm(i)
+ enddo
+ avg_s=avg_s/float(nsub)
+ avg_r=avg_r/float(nsub)
+!
+ s2=0.0
+ r2=0.0
+ sr=0.0
+ do i=1,nsub
+   ds=slip(i)-avg_s
+   dr=rstm(i)-avg_r
+   s2=s2+ds*ds
+   r2=r2+dr*dr
+   sr=sr+ds*dr
+ enddo
+ cr_srv=sr/sqrt(s2)/sqrt(r2)
+
+end subroutine coherent

--- a/shakermaker/ffsp/spfield_n.f90
+++ b/shakermaker/ffsp/spfield_n.f90
@@ -312,9 +312,12 @@ end subroutine mainfault
 !     Note that here we assume that the peaktime << risetime
 !     Chen Ji, 2020
 !
-subroutine random_field(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr,err_spectra)
+subroutine random_field_with_spectra(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr, &
+                                     err_spectra,stf_out,moment_rate_out, &
+                                     logmean_synth_out)
  use sp_sub_f
  use fdtim_2d
+ use time_freq
  implicit NONE
  integer, intent(INOUT):: idum1,idum2,idum3
  integer, parameter:: itrmax=5
@@ -322,6 +325,9 @@ subroutine random_field(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr,err_spectra)
  logical:: lloop,hloop
  integer:: i,j,k,iset,niter,is_stress
  real::ave_tr,ave_tp,ave_vr,err_spectra
+ real,dimension(ntime),intent(OUT):: stf_out
+ real,dimension(nphf),intent(OUT):: moment_rate_out
+ real,dimension(lnpt-1),intent(OUT):: logmean_synth_out
  real:: sum1,cmti,correct,cr0,cr1,cr2,csqt,cv0,cv1,cv2, &
         vrup,er_syn,er_target,cr_sr,cr_sv,gasdev
 
@@ -583,6 +589,11 @@ enddo
 write(*,*)"re-evaluate Quality of selected source model"
 call misfit_ratio(smoment,fc_main_1,fc_main_2,correct,err_spectra)
 write(*,*)"Misfit_ratio = ", correct,err_spectra
+! Capture the finalized realization while rstm and pktm still retain the
+! physical durations expected by sum_point_svf.  The transformations below
+! are only for the historical FFSP subfault output convention.
+call capture_spectral_realization(smoment,stf_out,moment_rate_out, &
+                                  logmean_synth_out)
 call coherent(cr_sv,nsum,rstm,pktm)
 write(*,*) 'cross-correlation between risetime(y) and peak time =',cr_sv
 do i=1,nsum
@@ -597,7 +608,6 @@ write(*,*) 'cross-correlation between risetime and peak time =',cr_sv
 do i=1,nsum
   pktm(i)=pktm(i)/rstm(i)
 end do
-call stf_synth_output(smoment,fc_main_1,fc_main_2)
 !
 ! scale the unit of seismic moment to N-m
   slip=slip*1.0e+15
@@ -625,6 +635,21 @@ call stf_synth_output(smoment,fc_main_1,fc_main_2)
   call filter_field(amz_prt,slip_clx,slip_cly,1.5,dx,dy,nsubx,nsuby)
   call random_rake(amz_prt,nsum)
 
+end subroutine random_field_with_spectra
+!
+!======================================================================
+! Preserve the standalone FFSP entry point used by ffsp_dcf_v2.f90.
+!
+subroutine random_field(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr,err_spectra)
+ use time_freq
+ implicit NONE
+ integer,intent(INOUT):: idum1,idum2,idum3
+ real,intent(OUT):: ave_tr,ave_tp,ave_vr,err_spectra
+ real,allocatable:: stf(:),moment_rate(:),logmean_synth(:)
+ allocate(stf(ntime),moment_rate(nphf),logmean_synth(lnpt-1))
+ call random_field_with_spectra(idum1,idum2,idum3,ave_tr,ave_tp,ave_vr, &
+                                err_spectra,stf,moment_rate,logmean_synth)
+ deallocate(stf,moment_rate,logmean_synth)
 end subroutine random_field
 !
 !======================================================================

--- a/shakermaker/ffspsource.py
+++ b/shakermaker/ffspsource.py
@@ -26,12 +26,120 @@ import os
 import numpy as np
 from typing import Optional, Dict, List
 from .crustmodel import CrustModel
+from .version import shakermaker_version
 
 FFSP_CITATION = (
     "FFSP finite-fault source - (c) 2005 Pengcheng Liu; modifications by Chen Ji "
     "(2020); based on Liu et al. (2006). Code obtained from the original authors "
     "and adapted for use within ShakerMaker."
 )
+
+FFSP_HDF5_SCHEMA_VERSION = "2.0"
+
+#: Magnitude-to-moment constant used internally by the FFSP kernel
+#: (``ffsp_wrapper.f90``): ``M0 = 10 ** (1.5 * Mw + 9.05)`` in N*m.  Hanks &
+#: Kanamori (1979) use 9.1 in SI; the fixed offset of 0.05/1.5 = 0.033 in
+#: magnitude is a convention difference, not a numerical error.
+FFSP_MAGNITUDE_CONSTANT = 9.05
+
+
+def _write_hdf_mapping(group, mapping):
+    """Write a nested result mapping without losing its logical structure."""
+    for key, value in mapping.items():
+        if isinstance(value, dict):
+            _write_hdf_mapping(group.create_group(key), value)
+        elif np.isscalar(value):
+            group.attrs[key] = value
+        else:
+            array = np.asarray(value)
+            options = {'compression': 'gzip', 'shuffle': True} if array.size else {}
+            group.create_dataset(key, data=array, **options)
+
+
+def _read_hdf_mapping(group):
+    """Reconstruct a nested result mapping written by _write_hdf_mapping."""
+    result = {key: value for key, value in group.attrs.items()}
+    for key, value in group.items():
+        result[key] = _read_hdf_mapping(value) if hasattr(value, 'items') else value[:]
+    return result
+
+
+def _validate_ffsp_kernel_contract(params):
+    """Reject inputs that would trigger a Fortran STOP or exceed ABI buffers."""
+    positive = ('fault_length', 'fault_width', 'rv_avg', 'freq_min', 'freq_max')
+    for name in positive:
+        if params[name] <= 0:
+            raise ValueError(f"{name} must be positive")
+    if params['freq_min'] >= params['freq_max']:
+        raise ValueError("freq_min must be smaller than freq_max")
+    if params['nsubx'] <= 0 or params['nsuby'] <= 0:
+        raise ValueError("nsubx and nsuby must be positive")
+    if params['id_ran2'] < params['id_ran1']:
+        raise ValueError("id_ran2 must be greater than or equal to id_ran1")
+    if params['id_ran1'] < 1:
+        raise ValueError("id_ran1 must be greater than or equal to 1")
+
+    seeds = params['seeds']
+    if len(seeds) != 3:
+        raise ValueError("seeds must contain exactly three integers")
+
+    # The f2py ABI and the FFSP kernel use default 32-bit Fortran INTEGERs.  Seed
+    # offsets are based on the global realization id, so validate them with Python
+    # integers before NumPy/Fortran can silently wrap.  seed1 is negated by the
+    # kernel for nsource > 1; excluding abs(INT32_MIN) also avoids its undefined
+    # two's-complement overflow in Fortran.
+    int32 = np.iinfo(np.int32)
+    for index, seed in enumerate(seeds, start=1):
+        if not isinstance(seed, (int, np.integer)):
+            raise TypeError(f"seed{index} must be an integer")
+        if not int32.min <= int(seed) <= int32.max:
+            raise ValueError(f"seed{index} is outside the int32 range")
+
+    for realization_id in {params['id_ran1'], params['id_ran2']}:
+        derived = (
+            int(seeds[0]) + (realization_id - 1) * 10000,
+            int(seeds[1]) + (realization_id - 1) * 20000,
+            int(seeds[2]) + (realization_id - 1) * 30000,
+        )
+        if realization_id > 1 and abs(derived[0]) > int32.max:
+            raise ValueError(
+                f"derived seed1 for realization {realization_id} exceeds int32")
+        for index, value in enumerate(derived[1:], start=2):
+            if not int32.min <= value <= int32.max:
+                raise ValueError(
+                    f"derived seed{index} for realization "
+                    f"{realization_id} exceeds int32")
+
+    dx = params['fault_length'] / params['nsubx']
+    dy = params['fault_width'] / params['nsuby']
+    ncxp = int(params['x_hypc'] / dx) + 1
+    ncyp = int(params['y_hypc'] / dy) + 1
+    if not (1 <= ncxp <= params['nsubx'] and 1 <= ncyp <= params['nsuby']):
+        raise ValueError("The hypocenter must lie inside the discretized fault")
+
+    ix = max(ncxp, params['nsubx'] - ncxp)
+    iy = max(ncyp, params['nsuby'] - ncyp)
+    maximum_distance = np.hypot(ix * dx, iy * dy)
+    minimum_average_velocity = params['rv_avg'] * 1.2 / 1.45
+    required_samples = int(maximum_distance / minimum_average_velocity / 0.001 + 1.0) * 10
+    ntime = 1
+    while ntime < required_samples:
+        ntime *= 2
+
+    if ntime > 131072:
+        raise ValueError(
+            f"FFSP requires ntime={ntime}, exceeding the f2py buffer limit 131072")
+
+    df = 1.0 / (ntime * 0.001)
+    lnpt = int(np.log(ntime) / np.log(2.0) + 0.1)
+    nfe1 = int(1.1 * params['freq_min'] / df) + 1
+    nfe2 = int(0.9 * params['freq_max'] / df) + 1
+    nbb = int(np.log(nfe1) / np.log(2.0))
+    nee = int(np.log(nfe2) / np.log(2.0)) + 1
+    if nbb < 1 or nee > lnpt - 1:
+        raise ValueError(
+            "The requested frequency band is outside the FFSP octave range: "
+            f"nbb={nbb}, nee={nee}, valid=[1, {lnpt - 1}]")
 
 
 # Finite Fault Stochastic Process (FFSP) source model
@@ -65,7 +173,7 @@ class FFSPSource:
                  verbose: bool = True):
         """
         Initialize FFSP source model.
-        
+
         Parameters
         ----------
         id_sf_type : int
@@ -95,7 +203,9 @@ class FFSPSource:
         nb_taper_trbl : List[int]
             Taper zones [top, right, bottom, left]
         seeds : List[int]
-            Random seeds [seed1, seed2, seed3]
+            Master random seeds [seed1, seed2, seed3]. Realizations are derived
+            deterministically from these seeds and their global realization ID;
+            realization 1 retains the historical FFSP reference stream.
         id_ran1, id_ran2 : int
             Realization range [start, end]
         angle_north_to_x : float
@@ -111,7 +221,7 @@ class FFSPSource:
         """
         if verbose:
             print(FFSP_CITATION)
-        
+
         if not isinstance(crust_model, CrustModel):
             raise TypeError("crust_model must be a CrustModel instance")
 
@@ -134,11 +244,11 @@ class FFSPSource:
             'is_moment': is_moment,
             'output_name': output_name,
         }
-        
+
         self.crust_model = crust_model
         self.output_name = output_name
         self.verbose = verbose
-        
+
         # Results storage
         self.all_realizations = None
         self.best_realization = None
@@ -161,6 +271,8 @@ class FFSPSource:
             Best realization subfault data (only valid on rank 0 if using MPI)
         """
         
+        _validate_ffsp_kernel_contract(self.params)
+
         # Detect MPI environment
         try:
             from mpi4py import MPI
@@ -195,6 +307,17 @@ class FFSPSource:
         
         if self.verbose and rank == 0:
             print(f"\nRunning FFSP: {total_models} realizations on {nprocs} MPI ranks\n")
+
+        if use_mpi and my_n_models == 0:
+            # More ranks than realizations is valid; idle ranks must not call
+            # f2py with an inverted realization range.
+            comm.send({'idle': True}, dest=0, tag=rank)
+            self.all_realizations = None
+            self.source_stats = None
+            self.best_realization = None
+            self.subfaults = None
+            self.active_realization = None
+            return None
         
         # Import Fortran wrapper module
         try:
@@ -243,10 +366,11 @@ class FFSPSource:
             self.crust_model.qb.astype(np.float32),
         )
         
-        # Unpack results from Fortran wrapper (27 values)
+        # Unpack kinematics, metrics, shared axes, and per-realization products.
         (n_realizations, npts, x, y, z, slip, rupture_time, 
          rise_time, peak_time, strike, dip, rake,
          ave_tr, ave_tp, ave_vr, err_spectra, pdf,
+         fc_main_1_effective, fc_main_2_effective,
          # Spectral data
          ntime_spec, nphf_spec, lnpt_spec,
          stf_time, stf,
@@ -270,9 +394,20 @@ class FFSPSource:
                 all_ave_vr = [ave_vr]
                 all_err_spectra = [err_spectra]
                 all_pdf = [pdf]
+                all_stf = [stf[:ntime_spec, :]]
+                all_moment_rate = [moment_rate[:nphf_spec, :]]
+                all_logmean_synth = [logmean_synth[:lnpt_spec, :]]
                 
                 for r in range(1, nprocs):
                     recv_data = comm.recv(source=r, tag=r)
+                    if recv_data.get('idle', False):
+                        continue
+
+                    remote_dims = (
+                        recv_data['ntime_spec'], recv_data['nphf_spec'],
+                        recv_data['lnpt_spec'])
+                    if remote_dims != (ntime_spec, nphf_spec, lnpt_spec):
+                        raise RuntimeError("MPI ranks returned inconsistent spectral dimensions")
                     
                     all_x.append(recv_data['x'])
                     all_y.append(recv_data['y'])
@@ -289,6 +424,19 @@ class FFSPSource:
                     all_ave_vr.append(recv_data['ave_vr'])
                     all_err_spectra.append(recv_data['err_spectra'])
                     all_pdf.append(recv_data['pdf'])
+                    all_stf.append(recv_data['stf'])
+                    all_moment_rate.append(recv_data['moment_rate'])
+                    all_logmean_synth.append(recv_data['logmean_synth'])
+
+                    # Every rank must use the same discretization and DCF target.
+                    for name, local, remote, length in (
+                            ('stf_time', stf_time, recv_data['stf_time'], ntime_spec),
+                            ('freq_spec', freq_spec, recv_data['freq_spec'], nphf_spec),
+                            ('dcf', dcf, recv_data['dcf'], nphf_spec),
+                            ('freq_center', freq_center, recv_data['freq_center'], lnpt_spec),
+                            ('logmean_dcf', logmean_dcf, recv_data['logmean_dcf'], lnpt_spec)):
+                        if not np.array_equal(local[:length], remote[:length]):
+                            raise RuntimeError(f"MPI ranks returned inconsistent {name}")
                 
                 # Concatenate all data
                 x = np.concatenate(all_x, axis=1)
@@ -306,6 +454,9 @@ class FFSPSource:
                 ave_vr = np.concatenate(all_ave_vr)
                 err_spectra = np.concatenate(all_err_spectra)
                 pdf = np.concatenate(all_pdf)
+                stf = np.concatenate(all_stf, axis=1)
+                moment_rate = np.concatenate(all_moment_rate, axis=1)
+                logmean_synth = np.concatenate(all_logmean_synth, axis=1)
                 
                 n_realizations = total_models
                 
@@ -326,6 +477,17 @@ class FFSPSource:
                     'ave_vr': ave_vr,
                     'err_spectra': err_spectra,
                     'pdf': pdf,
+                    'stf_time': stf_time,
+                    'stf': stf[:ntime_spec, :],
+                    'freq_spec': freq_spec,
+                    'moment_rate': moment_rate[:nphf_spec, :],
+                    'dcf': dcf,
+                    'freq_center': freq_center,
+                    'logmean_synth': logmean_synth[:lnpt_spec, :],
+                    'logmean_dcf': logmean_dcf,
+                    'ntime_spec': ntime_spec,
+                    'nphf_spec': nphf_spec,
+                    'lnpt_spec': lnpt_spec,
                 }
                 
                 comm.send(send_data, dest=0, tag=rank)
@@ -342,11 +504,21 @@ class FFSPSource:
         # Store results (only rank 0 in MPI mode, or single process)
         # =====================================================================
         
-        # Store all realizations in compatible format
+        self.params.setdefault('fc_main_1_requested', self.params['fc_main_1'])
+        self.params.setdefault('fc_main_2_requested', self.params['fc_main_2'])
+        self.params['fc_main_1'] = float(fc_main_1_effective)
+        self.params['fc_main_2'] = float(fc_main_2_effective)
+
+        realization_ids = np.arange(
+            self.params['id_ran1'], self.params['id_ran2'] + 1,
+            dtype=np.int32)
+
+        # Every realization is complete: kinematics, metrics, STF, and spectra.
         self.all_realizations = {
             'n_realizations': n_realizations,
             'nseg': 1,
             'npts': npts,
+            'realization_id': realization_ids,
             'x': x,
             'y': y,
             'z': z,
@@ -357,6 +529,27 @@ class FFSPSource:
             'strike': strike,
             'dip': dip,
             'rake': rake,
+            'metrics': {
+                'ave_tr': ave_tr,
+                'ave_tp': ave_tp,
+                'ave_vr': ave_vr,
+                'err_spectra': err_spectra,
+                'pdf': pdf,
+            },
+            'stf_time': {
+                'time': stf_time[:ntime_spec],
+                'stf': stf[:ntime_spec, :],
+            },
+            'spectrum': {
+                'freq': freq_spec[:nphf_spec],
+                'moment_rate_synth': moment_rate[:nphf_spec, :],
+                'moment_rate_dcf': dcf[:nphf_spec],
+            },
+            'spectrum_octave': {
+                'freq_center': freq_center[:lnpt_spec],
+                'logmean_synth': logmean_synth[:lnpt_spec, :],
+                'logmean_dcf': logmean_dcf[:lnpt_spec],
+            },
         }
         
         # Store statistics (for plots)
@@ -369,44 +562,21 @@ class FFSPSource:
                 'err_spectra': err_spectra,
                 'pdf': pdf,
             },
-            # Spectral data (from best realization computed by rank 0 or single process)
-            'spectrum': {
-                'freq': freq_spec[:nphf_spec],
-                'moment_rate_synth': moment_rate[:nphf_spec],
-                'moment_rate_dcf': dcf[:nphf_spec],
-            },
-            'stf_time': {
-                'time': stf_time[:ntime_spec],
-                'stf': stf[:ntime_spec],
-            },
-            'spectrum_octave': {
-                'freq_center': freq_center[:lnpt_spec],
-                'logmean_synth': logmean_synth[:lnpt_spec],
-                'logmean_dcf': logmean_dcf[:lnpt_spec],
-            }
         }
         
         # Identify best realization (minimum PDF)
-        best_idx = np.argmin(pdf)
-        self.best_realization = {
-            'nseg': 1,
-            'npts': npts,
-            'x': x[:, best_idx],
-            'y': y[:, best_idx],
-            'z': z[:, best_idx],
-            'slip': slip[:, best_idx],
-            'rupture_time': rupture_time[:, best_idx],
-            'rise_time': rise_time[:, best_idx],
-            'peak_time': peak_time[:, best_idx],
-            'strike': strike[:, best_idx],
-            'dip': dip[:, best_idx],
-            'rake': rake[:, best_idx],
-        }
-        
+        best_idx = int(np.argmin(pdf))
+        self.best_realization = self.get_realization(best_idx)
+
+        # Preserve the historical statistics paths as aliases to the best model.
+        self.source_stats['stf_time'] = self.best_realization['stf_time']
+        self.source_stats['spectrum'] = self.best_realization['spectrum']
+        self.source_stats['spectrum_octave'] = self.best_realization['spectrum_octave']
+
         # Set best realization as active subfaults
         self.subfaults = self.best_realization
         self.active_realization = 'best'
-        
+
         if self.verbose and (rank == 0 or not use_mpi):
             print(f"\nFFSP Complete: {n_realizations} realizations | Best: PDF={pdf[best_idx]:.4f}\n")
         
@@ -434,9 +604,13 @@ class FFSPSource:
         if not (0 <= index < n):
             raise IndexError(f"Index {index} out of range [0, {n-1}]")
         
-        return {
+        result = {
             'nseg': self.all_realizations['nseg'],
             'npts': self.all_realizations['npts'],
+            'realization_id': int(self.all_realizations.get(
+                'realization_id',
+                np.arange(self.params['id_ran1'], self.params['id_ran2'] + 1),
+            )[index]),
             'x': self.all_realizations['x'][:, index],
             'y': self.all_realizations['y'][:, index],
             'z': self.all_realizations['z'][:, index],
@@ -448,6 +622,30 @@ class FFSPSource:
             'dip': self.all_realizations['dip'][:, index],
             'rake': self.all_realizations['rake'][:, index],
         }
+
+        if 'metrics' in self.all_realizations:
+            result['metrics'] = {
+                key: np.asarray(value)[index]
+                for key, value in self.all_realizations['metrics'].items()
+            }
+        if 'stf_time' in self.all_realizations:
+            result['stf_time'] = {
+                'time': self.all_realizations['stf_time']['time'],
+                'stf': self.all_realizations['stf_time']['stf'][:, index],
+            }
+        if 'spectrum' in self.all_realizations:
+            result['spectrum'] = {
+                'freq': self.all_realizations['spectrum']['freq'],
+                'moment_rate_synth': self.all_realizations['spectrum']['moment_rate_synth'][:, index],
+                'moment_rate_dcf': self.all_realizations['spectrum']['moment_rate_dcf'],
+            }
+        if 'spectrum_octave' in self.all_realizations:
+            result['spectrum_octave'] = {
+                'freq_center': self.all_realizations['spectrum_octave']['freq_center'],
+                'logmean_synth': self.all_realizations['spectrum_octave']['logmean_synth'][:, index],
+                'logmean_dcf': self.all_realizations['spectrum_octave']['logmean_dcf'],
+            }
+        return result
 
     def set_active_realization(self, index: int):
         """Set active realization for plotting."""
@@ -497,44 +695,22 @@ class FFSPSource:
         print(f"Writing HDF5: {filename}")
         
         with h5py.File(filename, 'w') as f:
+            f.attrs['schema_version'] = FFSP_HDF5_SCHEMA_VERSION
+            f.attrs['shakermaker_version'] = shakermaker_version
+            f.attrs['best_realization_id'] = self.best_realization['realization_id']
             grp_realizations = f.create_group('realizations')
             grp_best = f.create_group('best_realization')
             grp_stats = f.create_group('statistics')
             grp_params = f.create_group('parameters')
             
-            for key, val in self.all_realizations.items():
-                if isinstance(val, (int, float)):
-                    grp_realizations.attrs[key] = val
-                else:
-                    grp_realizations.create_dataset(key, data=val, compression='gzip')
+            _write_hdf_mapping(grp_realizations, self.all_realizations)
             
             if self.best_realization is not None:
-                for key, val in self.best_realization.items():
-                    if isinstance(val, (int, float)):
-                        grp_best.attrs[key] = val
-                    else:
-                        grp_best.create_dataset(key, data=val, compression='gzip')
+                _write_hdf_mapping(grp_best, self.best_realization)
             
             if self.source_stats is not None:
-                grp_score = grp_stats.create_group('source_score')
-                for key, val in self.source_stats['source_score'].items():
-                    if isinstance(val, (int, float)):
-                        grp_score.attrs[key] = val
-                    else:
-                        grp_score.create_dataset(key, data=val, compression='gzip')
-                
-                if 'spectrum' in self.source_stats:
-                    grp_spectrum = grp_stats.create_group('spectrum')
-                    for key, val in self.source_stats['spectrum'].items():
-                        grp_spectrum.create_dataset(key, data=val, compression='gzip')
-                    
-                    grp_stf = grp_stats.create_group('stf_time')
-                    for key, val in self.source_stats['stf_time'].items():
-                        grp_stf.create_dataset(key, data=val, compression='gzip')
-                    
-                    grp_octave = grp_stats.create_group('spectrum_octave')
-                    for key, val in self.source_stats['spectrum_octave'].items():
-                        grp_octave.create_dataset(key, data=val, compression='gzip')
+                _write_hdf_mapping(grp_stats, self.source_stats)
+                grp_stats.attrs['realization_id'] = self.best_realization['realization_id']
             
             for key, val in self.params.items():
                 if isinstance(val, (int, float, str)):
@@ -579,44 +755,20 @@ class FFSPSource:
         
         with h5py.File(filename, 'r') as f:
             # Load all realizations
-            grp_realizations = f['realizations']
-            self.all_realizations = {}
-            for key in grp_realizations.keys():
-                self.all_realizations[key] = grp_realizations[key][:]
-            for key in grp_realizations.attrs.keys():
-                self.all_realizations[key] = grp_realizations.attrs[key]
+            self.all_realizations = _read_hdf_mapping(f['realizations'])
             
             # Load best realization
-            grp_best = f['best_realization']
-            self.best_realization = {}
-            for key in grp_best.keys():
-                self.best_realization[key] = grp_best[key][:]
-            for key in grp_best.attrs.keys():
-                self.best_realization[key] = grp_best.attrs[key]
+            self.best_realization = _read_hdf_mapping(f['best_realization'])
             
             # Load statistics
-            grp_stats = f['statistics']
-            self.source_stats = {}
-            
-            grp_score = grp_stats['source_score']
-            self.source_stats['source_score'] = {}
-            for key in grp_score.keys():
-                self.source_stats['source_score'][key] = grp_score[key][:]
-            for key in grp_score.attrs.keys():
-                self.source_stats['source_score'][key] = grp_score.attrs[key]
-            
-            if 'spectrum' in grp_stats:
-                self.source_stats['spectrum'] = {}
-                for key in grp_stats['spectrum'].keys():
-                    self.source_stats['spectrum'][key] = grp_stats['spectrum'][key][:]
-                
-                self.source_stats['stf_time'] = {}
-                for key in grp_stats['stf_time'].keys():
-                    self.source_stats['stf_time'][key] = grp_stats['stf_time'][key][:]
-                
-                self.source_stats['spectrum_octave'] = {}
-                for key in grp_stats['spectrum_octave'].keys():
-                    self.source_stats['spectrum_octave'][key] = grp_stats['spectrum_octave'][key][:]
+            self.source_stats = _read_hdf_mapping(f['statistics'])
+
+            # Older files stored spectral products only under /statistics.
+            # Keep those products attached to the loaded best realization
+            # without presenting them as data for every realization.
+            for group_name in ('stf_time', 'spectrum', 'spectrum_octave'):
+                if group_name not in self.best_realization and group_name in self.source_stats:
+                    self.best_realization[group_name] = self.source_stats[group_name]
             
             # Load parameters
             grp_params = f['parameters']
@@ -2249,12 +2401,12 @@ class FFSPSource:
     def plot_spectral_comparison(self, figsize=(14, 6)):
         """Plot Moment Rate Spectrum and Octave-Averaged Spectrum side by side."""
         import matplotlib.pyplot as plt
-        if self.source_stats is None:
+        if self.subfaults is None or 'spectrum' not in self.subfaults:
             print("No source statistics available. Run simulation first.")
             return
         
-        spectrum = self.source_stats['spectrum']
-        octave = self.source_stats['spectrum_octave']
+        spectrum = self.subfaults['spectrum']
+        octave = self.subfaults['spectrum_octave']
         plt.figure(figsize=figsize)
         
         # Normalize to compare shapes
@@ -2291,20 +2443,32 @@ class FFSPSource:
 
     def plot_source_time_function(self, figsize=(10, 6),xlim=None,
                                 save_fig=False, model_name='source', image_type='png'):
-        """Plot Source Time Function (STF)."""
+        """Plot Source Time Function (STF).
+
+        The stored STF is normalised to unit area by the kernel, so its unit is
+        1/s, not N*m/s.  Multiply by the scalar moment to obtain a physical
+        moment rate: ``M0 = 10 ** (1.5 * magnitude + 9.05)``, using FFSP's own
+        magnitude constant 9.05 rather than the SI 9.1 of Hanks & Kanamori.
+        """
         import matplotlib.pyplot as plt
-        if self.source_stats is None:
+        if self.subfaults is None or 'stf_time' not in self.subfaults:
             print("No source statistics available. Run simulation first.")
             return
-        
-        stf = self.source_stats['stf_time']
+
+        stf = self.subfaults['stf_time']
+        # The kernel stores the STF with unit area, so it is a rate in 1/s.
+        # Scaling by the scalar moment turns it into a physical moment rate.
+        M0 = 10.0 ** (1.5 * float(self.params['magnitude']) + FFSP_MAGNITUDE_CONSTANT)
+        moment_rate = np.asarray(stf['stf'], dtype=float) * M0
+
         plt.figure(figsize=figsize)
-        plt.plot(stf['time'], stf['stf'], color='black', lw=1.5, label='STF')
-        plt.fill_between(stf['time'], 0, stf['stf'], alpha=0.3, color='tab:cyan')
-        max_idx = np.argmax(stf['stf'])
-        plt.plot(stf['time'][max_idx], stf['stf'][max_idx], 'o', color='tab:red', markersize=12, label=f'Peak at t={stf["time"][max_idx]:.2f} s')
+        plt.plot(stf['time'], moment_rate, color='black', lw=1.5, label='STF')
+        plt.fill_between(stf['time'], 0, moment_rate, alpha=0.3, color='tab:cyan')
+        max_idx = np.argmax(moment_rate)
+        plt.plot(stf['time'][max_idx], moment_rate[max_idx], 'o', color='tab:red', markersize=12,
+                 label=f'Peak {moment_rate[max_idx]:.3e} N m/s at t={stf["time"][max_idx]:.2f} s')
         plt.xlabel('Time (s)', fontsize=12)
-        plt.ylabel('Moment Rate', fontsize=12)
+        plt.ylabel(r'$\dot{M}_0$ (N m/s)', fontsize=12)
         plt.title('Source Time Function (STF)', fontsize=14, fontweight='bold')
         plt.legend(fontsize=11)
         plt.grid(alpha=0.3)

--- a/shakermaker/ffspsource.py
+++ b/shakermaker/ffspsource.py
@@ -1,0 +1,2572 @@
+"""FFSP finite-fault stochastic source model.
+
+``FFSPSource`` wraps the FFSP stochastic-rupture kernel (Pengcheng Liu, (c) 2005;
+modifications by Chen Ji, 2020) and exposes it as a ShakerMaker source. It generates
+physically-admissible stochastic slip / slip-rate distributions on a fault plane from a
+deterministic skeleton (magnitude, geometry, mechanism, hypocentre, spectrum) plus random
+fields, and produces an ensemble of realizations.
+
+What it provides
+----------------
+- Generation: ``run`` computes an ensemble of realizations; ``get_realization``,
+  ``set_active_realization`` and ``get_subfaults`` inspect them.
+- Persistence:
+  - HDF5: ``write_hdf5`` / ``load_hdf5`` / classmethod ``from_hdf5``.
+  - Native FFSP text format: ``write_ffsp_format`` / ``load_ffsp_format`` /
+    classmethod ``from_ffsp_format`` (with the ``_load_*`` / ``_parse_ffsp_inp`` helpers).
+- Plotting (matplotlib, imported lazily): ``plot_histogram``, ``plot_spacial_distribution``,
+  ``plot_rupture_snapshot``, ``plot_quality_metrics``, ``plot_temporal_metrics``,
+  ``plot_spectral_comparison``, ``plot_source_time_function``, ``plot_crust_layers``,
+  ``create_animation``.
+- MPI-aware: ensemble generation is distributed across MPI ranks.
+
+See ``docs/web/guides/ffsp.md`` for the user guide and ``FFSP_CITATION`` for attribution.
+"""
+import os
+import numpy as np
+from typing import Optional, Dict, List
+from .crustmodel import CrustModel
+
+FFSP_CITATION = (
+    "FFSP finite-fault source - (c) 2005 Pengcheng Liu; modifications by Chen Ji "
+    "(2020); based on Liu et al. (2006). Code obtained from the original authors "
+    "and adapted for use within ShakerMaker."
+)
+
+
+# Finite Fault Stochastic Process (FFSP) source model
+class FFSPSource:
+    """Finite Fault Stochastic Process source model (Pengcheng Liu, (c) 2005;
+    modifications by Chen Ji, 2020).
+
+    An MPI-aware wrapper over the FFSP kernel that generates an ensemble of stochastic
+    finite-fault realizations and exposes HDF5 and native FFSP-format I/O plus plotting.
+    See the module docstring for the full capability list.
+    """
+    
+    def __init__(self,
+                 id_sf_type: int, freq_min: float, freq_max: float,
+                 fault_length: float, fault_width: float,
+                 x_hypc: float, y_hypc: float, depth_hypc: float,
+                 xref_hypc: float, yref_hypc: float,
+                 magnitude: float, fc_main_1: float, fc_main_2: float,
+                 rv_avg: float,
+                 ratio_rise: float,
+                 strike: float, dip: float, rake: float,
+                 pdip_max: float, prake_max: float,
+                 nsubx: int, nsuby: int,
+                 nb_taper_trbl: List[int],
+                 seeds: List[int],
+                 id_ran1: int, id_ran2: int,
+                 angle_north_to_x: float,
+                 is_moment: int,
+                 crust_model: CrustModel,
+                 output_name: str = "FFSP_OUTPUT",
+                 verbose: bool = True):
+        """
+        Initialize FFSP source model.
+        
+        Parameters
+        ----------
+        id_sf_type : int
+            Slip function type
+        freq_min, freq_max : float
+            Frequency range (Hz)
+        fault_length, fault_width : float
+            Fault dimensions (km)
+        x_hypc, y_hypc, depth_hypc : float
+            Hypocenter position (km)
+        xref_hypc, yref_hypc : float
+            Reference position for hypocenter
+        magnitude : float
+            Moment magnitude
+        fc_main_1, fc_main_2 : float
+            Corner frequencies (Hz)
+        rv_avg : float
+            Average rupture velocity (km/s)
+        ratio_rise : float
+            Rise time ratio
+        strike, dip, rake : float
+            Fault geometry (degrees)
+        pdip_max, prake_max : float
+            Maximum perturbations (degrees)
+        nsubx, nsuby : int
+            Number of subfaults along strike and dip
+        nb_taper_trbl : List[int]
+            Taper zones [top, right, bottom, left]
+        seeds : List[int]
+            Random seeds [seed1, seed2, seed3]
+        id_ran1, id_ran2 : int
+            Realization range [start, end]
+        angle_north_to_x : float
+            Rotation angle (degrees)
+        is_moment : int
+            Result flag
+        crust_model : CrustModel
+            Velocity model
+        output_name : str, optional
+            Output file prefix
+        verbose : bool, optional
+            Print progress messages
+        """
+        if verbose:
+            print(FFSP_CITATION)
+        
+        if not isinstance(crust_model, CrustModel):
+            raise TypeError("crust_model must be a CrustModel instance")
+
+        # Store all parameters
+        self.params = {
+            'id_sf_type': id_sf_type, 'freq_min': freq_min, 'freq_max': freq_max,
+            'fault_length': fault_length, 'fault_width': fault_width,
+            'x_hypc': x_hypc, 'y_hypc': y_hypc, 'depth_hypc': depth_hypc,
+            'xref_hypc': xref_hypc, 'yref_hypc': yref_hypc,
+            'magnitude': magnitude, 'fc_main_1': fc_main_1, 'fc_main_2': fc_main_2,
+            'rv_avg': rv_avg,
+            'ratio_rise': ratio_rise,
+            'strike': strike, 'dip': dip, 'rake': rake,
+            'pdip_max': pdip_max, 'prake_max': prake_max,
+            'nsubx': nsubx, 'nsuby': nsuby,
+            'nb_taper_trbl': nb_taper_trbl,
+            'seeds': seeds,
+            'id_ran1': id_ran1, 'id_ran2': id_ran2,
+            'angle_north_to_x': angle_north_to_x,
+            'is_moment': is_moment,
+            'output_name': output_name,
+        }
+        
+        self.crust_model = crust_model
+        self.output_name = output_name
+        self.verbose = verbose
+        
+        # Results storage
+        self.all_realizations = None
+        self.best_realization = None
+        self.source_stats = None
+        self.subfaults = None
+
+        # Subfault dimensions
+        self.dx = fault_length / nsubx
+        self.dy = fault_width / nsuby
+        self.area = self.dx * self.dy
+    
+    def run(self) -> Dict:
+        """
+        Run FFSP to generate fault realizations using Fortran wrapper.
+        Supports MPI parallelization with automatic data gathering.
+        
+        Returns
+        -------
+        Dict
+            Best realization subfault data (only valid on rank 0 if using MPI)
+        """
+        
+        # Detect MPI environment
+        try:
+            from mpi4py import MPI
+            comm = MPI.COMM_WORLD
+            use_mpi = comm.Get_size() > 1
+            rank = comm.Get_rank() if use_mpi else 0
+            nprocs = comm.Get_size() if use_mpi else 1
+        except ImportError:
+            use_mpi = False
+            rank = 0
+            nprocs = 1
+        
+        # Distribute realizations across MPI ranks
+        total_models = self.params['id_ran2'] - self.params['id_ran1'] + 1
+        
+        if use_mpi:
+            models_per_rank = total_models // nprocs
+            remainder = total_models % nprocs
+            
+            if rank < remainder:
+                start = rank * (models_per_rank + 1) + self.params['id_ran1']
+                end = start + models_per_rank
+            else:
+                start = rank * models_per_rank + remainder + self.params['id_ran1']
+                end = start + models_per_rank - 1
+            
+            my_n_models = end - start + 1
+        else:
+            start = self.params['id_ran1']
+            end = self.params['id_ran2']
+            my_n_models = total_models
+        
+        if self.verbose and rank == 0:
+            print(f"\nRunning FFSP: {total_models} realizations on {nprocs} MPI ranks\n")
+        
+        # Import Fortran wrapper module
+        try:
+            from shakermaker.ffsp import ffsp_core
+        except ImportError:
+            # Fallback: add ffsp directory to path
+            import sys
+            ffsp_dir = os.path.join(os.path.dirname(__file__), 'ffsp')
+            sys.path.insert(0, ffsp_dir)
+            import ffsp_core
+        
+        result = ffsp_core.ffsp_run_wrapper(
+            self.params['id_sf_type'],
+            self.params['freq_min'],
+            self.params['freq_max'],
+            self.params['fault_length'],
+            self.params['fault_width'],
+            self.params['x_hypc'],
+            self.params['y_hypc'],
+            self.params['depth_hypc'],
+            self.params['xref_hypc'],
+            self.params['yref_hypc'],
+            self.params['magnitude'],
+            self.params['fc_main_1'],
+            self.params['fc_main_2'],
+            self.params['rv_avg'],
+            self.params['ratio_rise'],
+            self.params['strike'],
+            self.params['dip'],
+            self.params['rake'],
+            self.params['pdip_max'],
+            self.params['prake_max'],
+            self.params['nsubx'],
+            self.params['nsuby'],
+            np.array(self.params['nb_taper_trbl'], dtype=np.int32),
+            np.array(self.params['seeds'], dtype=np.int32),
+            start, end,
+            self.params['angle_north_to_x'],
+            self.params['is_moment'],
+            self.crust_model.nlayers,
+            self.crust_model.a.astype(np.float32),
+            self.crust_model.b.astype(np.float32),
+            self.crust_model.rho.astype(np.float32),
+            self.crust_model.d.astype(np.float32),
+            self.crust_model.qa.astype(np.float32),
+            self.crust_model.qb.astype(np.float32),
+        )
+        
+        # Unpack results from Fortran wrapper (27 values)
+        (n_realizations, npts, x, y, z, slip, rupture_time, 
+         rise_time, peak_time, strike, dip, rake,
+         ave_tr, ave_tp, ave_vr, err_spectra, pdf,
+         # Spectral data
+         ntime_spec, nphf_spec, lnpt_spec,
+         stf_time, stf,
+         freq_spec, moment_rate, dcf,
+         freq_center, logmean_synth, logmean_dcf) = result
+        
+        if use_mpi:
+            if rank == 0:
+                all_x = [x]
+                all_y = [y]
+                all_z = [z]
+                all_slip = [slip]
+                all_rupture_time = [rupture_time]
+                all_rise_time = [rise_time]
+                all_peak_time = [peak_time]
+                all_strike = [strike]
+                all_dip = [dip]
+                all_rake = [rake]
+                all_ave_tr = [ave_tr]
+                all_ave_tp = [ave_tp]
+                all_ave_vr = [ave_vr]
+                all_err_spectra = [err_spectra]
+                all_pdf = [pdf]
+                
+                for r in range(1, nprocs):
+                    recv_data = comm.recv(source=r, tag=r)
+                    
+                    all_x.append(recv_data['x'])
+                    all_y.append(recv_data['y'])
+                    all_z.append(recv_data['z'])
+                    all_slip.append(recv_data['slip'])
+                    all_rupture_time.append(recv_data['rupture_time'])
+                    all_rise_time.append(recv_data['rise_time'])
+                    all_peak_time.append(recv_data['peak_time'])
+                    all_strike.append(recv_data['strike'])
+                    all_dip.append(recv_data['dip'])
+                    all_rake.append(recv_data['rake'])
+                    all_ave_tr.append(recv_data['ave_tr'])
+                    all_ave_tp.append(recv_data['ave_tp'])
+                    all_ave_vr.append(recv_data['ave_vr'])
+                    all_err_spectra.append(recv_data['err_spectra'])
+                    all_pdf.append(recv_data['pdf'])
+                
+                # Concatenate all data
+                x = np.concatenate(all_x, axis=1)
+                y = np.concatenate(all_y, axis=1)
+                z = np.concatenate(all_z, axis=1)
+                slip = np.concatenate(all_slip, axis=1)
+                rupture_time = np.concatenate(all_rupture_time, axis=1)
+                rise_time = np.concatenate(all_rise_time, axis=1)
+                peak_time = np.concatenate(all_peak_time, axis=1)
+                strike = np.concatenate(all_strike, axis=1)
+                dip = np.concatenate(all_dip, axis=1)
+                rake = np.concatenate(all_rake, axis=1)
+                ave_tr = np.concatenate(all_ave_tr)
+                ave_tp = np.concatenate(all_ave_tp)
+                ave_vr = np.concatenate(all_ave_vr)
+                err_spectra = np.concatenate(all_err_spectra)
+                pdf = np.concatenate(all_pdf)
+                
+                n_realizations = total_models
+                
+            else:
+                send_data = {
+                    'x': x,
+                    'y': y,
+                    'z': z,
+                    'slip': slip,
+                    'rupture_time': rupture_time,
+                    'rise_time': rise_time,
+                    'peak_time': peak_time,
+                    'strike': strike,
+                    'dip': dip,
+                    'rake': rake,
+                    'ave_tr': ave_tr,
+                    'ave_tp': ave_tp,
+                    'ave_vr': ave_vr,
+                    'err_spectra': err_spectra,
+                    'pdf': pdf,
+                }
+                
+                comm.send(send_data, dest=0, tag=rank)
+                
+                self.all_realizations = None
+                self.source_stats = None
+                self.best_realization = None
+                self.subfaults = None
+                self.active_realization = None
+                
+                return None
+        
+        # =====================================================================
+        # Store results (only rank 0 in MPI mode, or single process)
+        # =====================================================================
+        
+        # Store all realizations in compatible format
+        self.all_realizations = {
+            'n_realizations': n_realizations,
+            'nseg': 1,
+            'npts': npts,
+            'x': x,
+            'y': y,
+            'z': z,
+            'slip': slip,
+            'rupture_time': rupture_time,
+            'rise_time': rise_time,
+            'peak_time': peak_time,
+            'strike': strike,
+            'dip': dip,
+            'rake': rake,
+        }
+        
+        # Store statistics (for plots)
+        self.source_stats = {
+            'source_score': {
+                'n_realizations': n_realizations,
+                'ave_tr': ave_tr,
+                'ave_tp': ave_tp,
+                'ave_vr': ave_vr,
+                'err_spectra': err_spectra,
+                'pdf': pdf,
+            },
+            # Spectral data (from best realization computed by rank 0 or single process)
+            'spectrum': {
+                'freq': freq_spec[:nphf_spec],
+                'moment_rate_synth': moment_rate[:nphf_spec],
+                'moment_rate_dcf': dcf[:nphf_spec],
+            },
+            'stf_time': {
+                'time': stf_time[:ntime_spec],
+                'stf': stf[:ntime_spec],
+            },
+            'spectrum_octave': {
+                'freq_center': freq_center[:lnpt_spec],
+                'logmean_synth': logmean_synth[:lnpt_spec],
+                'logmean_dcf': logmean_dcf[:lnpt_spec],
+            }
+        }
+        
+        # Identify best realization (minimum PDF)
+        best_idx = np.argmin(pdf)
+        self.best_realization = {
+            'nseg': 1,
+            'npts': npts,
+            'x': x[:, best_idx],
+            'y': y[:, best_idx],
+            'z': z[:, best_idx],
+            'slip': slip[:, best_idx],
+            'rupture_time': rupture_time[:, best_idx],
+            'rise_time': rise_time[:, best_idx],
+            'peak_time': peak_time[:, best_idx],
+            'strike': strike[:, best_idx],
+            'dip': dip[:, best_idx],
+            'rake': rake[:, best_idx],
+        }
+        
+        # Set best realization as active subfaults
+        self.subfaults = self.best_realization
+        self.active_realization = 'best'
+        
+        if self.verbose and (rank == 0 or not use_mpi):
+            print(f"\nFFSP Complete: {n_realizations} realizations | Best: PDF={pdf[best_idx]:.4f}\n")
+        
+        return self.subfaults
+
+    def get_realization(self, index: int) -> Dict:
+        """
+        Get specific realization by index (0-based).
+        
+        Parameters
+        ----------
+        index : int
+            Realization index
+            
+        Returns
+        -------
+        Dict
+            Realization data
+        """
+        
+        if not hasattr(self, 'all_realizations') or not self.all_realizations:
+            raise RuntimeError("No realizations available. Run FFSP first.")
+        
+        n = self.all_realizations['n_realizations']
+        if not (0 <= index < n):
+            raise IndexError(f"Index {index} out of range [0, {n-1}]")
+        
+        return {
+            'nseg': self.all_realizations['nseg'],
+            'npts': self.all_realizations['npts'],
+            'x': self.all_realizations['x'][:, index],
+            'y': self.all_realizations['y'][:, index],
+            'z': self.all_realizations['z'][:, index],
+            'slip': self.all_realizations['slip'][:, index],
+            'rupture_time': self.all_realizations['rupture_time'][:, index],
+            'rise_time': self.all_realizations['rise_time'][:, index],
+            'peak_time': self.all_realizations['peak_time'][:, index],
+            'strike': self.all_realizations['strike'][:, index],
+            'dip': self.all_realizations['dip'][:, index],
+            'rake': self.all_realizations['rake'][:, index],
+        }
+
+    def set_active_realization(self, index: int):
+        """Set active realization for plotting."""
+        self.subfaults = self.get_realization(index)
+        self.active_realization = index
+        # Detect MPI rank
+        try:
+            from mpi4py import MPI
+            rank = MPI.COMM_WORLD.Get_rank()
+        except (ImportError, AttributeError):
+            rank = 0
+
+        if self.verbose and rank == 0:
+            print(f"Realization #{index+1} activated")
+
+    def get_subfaults(self) -> Dict:
+        """Get currently active subfault data."""
+        if self.subfaults is None:
+            raise RuntimeError("No active realization. Call set_active_realization() first.")
+        return self.subfaults 
+    
+    # ============ FILE WRITING METHODS ============
+    
+    
+    def write_hdf5(self, filename: str):
+        """
+        Write results to HDF5 file (modern, efficient format).
+        Stores all realizations and metadata in a single compressed file.
+        
+        Parameters
+        ----------
+        filename : str
+            Output HDF5 filename (will add .h5 if not present)
+        """
+        
+        if self.all_realizations is None:
+            raise RuntimeError("No realizations available. Run FFSP first.")
+        
+        try:
+            import h5py
+        except ImportError:
+            raise ImportError("h5py required for HDF5 output. Install with: pip install h5py")
+        
+        if not filename.endswith('.h5'):
+            filename += '.h5'
+        
+        print(f"Writing HDF5: {filename}")
+        
+        with h5py.File(filename, 'w') as f:
+            grp_realizations = f.create_group('realizations')
+            grp_best = f.create_group('best_realization')
+            grp_stats = f.create_group('statistics')
+            grp_params = f.create_group('parameters')
+            
+            for key, val in self.all_realizations.items():
+                if isinstance(val, (int, float)):
+                    grp_realizations.attrs[key] = val
+                else:
+                    grp_realizations.create_dataset(key, data=val, compression='gzip')
+            
+            if self.best_realization is not None:
+                for key, val in self.best_realization.items():
+                    if isinstance(val, (int, float)):
+                        grp_best.attrs[key] = val
+                    else:
+                        grp_best.create_dataset(key, data=val, compression='gzip')
+            
+            if self.source_stats is not None:
+                grp_score = grp_stats.create_group('source_score')
+                for key, val in self.source_stats['source_score'].items():
+                    if isinstance(val, (int, float)):
+                        grp_score.attrs[key] = val
+                    else:
+                        grp_score.create_dataset(key, data=val, compression='gzip')
+                
+                if 'spectrum' in self.source_stats:
+                    grp_spectrum = grp_stats.create_group('spectrum')
+                    for key, val in self.source_stats['spectrum'].items():
+                        grp_spectrum.create_dataset(key, data=val, compression='gzip')
+                    
+                    grp_stf = grp_stats.create_group('stf_time')
+                    for key, val in self.source_stats['stf_time'].items():
+                        grp_stf.create_dataset(key, data=val, compression='gzip')
+                    
+                    grp_octave = grp_stats.create_group('spectrum_octave')
+                    for key, val in self.source_stats['spectrum_octave'].items():
+                        grp_octave.create_dataset(key, data=val, compression='gzip')
+            
+            for key, val in self.params.items():
+                if isinstance(val, (int, float, str)):
+                    grp_params.attrs[key] = val
+                elif isinstance(val, list):
+                    grp_params.create_dataset(key, data=np.array(val))
+            
+            grp_params.attrs['dx'] = self.dx
+            grp_params.attrs['dy'] = self.dy
+            grp_params.attrs['area'] = self.area
+            
+            grp_crust = grp_params.create_group('crust_model')
+            grp_crust.attrs['nlayers'] = self.crust_model.nlayers
+            grp_crust.create_dataset('d', data=self.crust_model.d)
+            grp_crust.create_dataset('a', data=self.crust_model.a)
+            grp_crust.create_dataset('b', data=self.crust_model.b)
+            grp_crust.create_dataset('rho', data=self.crust_model.rho)
+            grp_crust.create_dataset('qa', data=self.crust_model.qa)
+            grp_crust.create_dataset('qb', data=self.crust_model.qb)
+        
+        print(f"[OK] HDF5 saved\n")
+    
+    def load_hdf5(self, filename: str):
+        """
+        Load results from HDF5 file into existing FFSPSource object.
+        
+        Parameters
+        ----------
+        filename : str
+            Input HDF5 filename
+        """
+        
+        try:
+            import h5py
+        except ImportError:
+            raise ImportError("h5py required for HDF5 input. Install with: pip install h5py")
+        
+        if not filename.endswith('.h5'):
+            filename += '.h5'
+        
+        print(f"Loading HDF5: {filename}")
+        
+        with h5py.File(filename, 'r') as f:
+            # Load all realizations
+            grp_realizations = f['realizations']
+            self.all_realizations = {}
+            for key in grp_realizations.keys():
+                self.all_realizations[key] = grp_realizations[key][:]
+            for key in grp_realizations.attrs.keys():
+                self.all_realizations[key] = grp_realizations.attrs[key]
+            
+            # Load best realization
+            grp_best = f['best_realization']
+            self.best_realization = {}
+            for key in grp_best.keys():
+                self.best_realization[key] = grp_best[key][:]
+            for key in grp_best.attrs.keys():
+                self.best_realization[key] = grp_best.attrs[key]
+            
+            # Load statistics
+            grp_stats = f['statistics']
+            self.source_stats = {}
+            
+            grp_score = grp_stats['source_score']
+            self.source_stats['source_score'] = {}
+            for key in grp_score.keys():
+                self.source_stats['source_score'][key] = grp_score[key][:]
+            for key in grp_score.attrs.keys():
+                self.source_stats['source_score'][key] = grp_score.attrs[key]
+            
+            if 'spectrum' in grp_stats:
+                self.source_stats['spectrum'] = {}
+                for key in grp_stats['spectrum'].keys():
+                    self.source_stats['spectrum'][key] = grp_stats['spectrum'][key][:]
+                
+                self.source_stats['stf_time'] = {}
+                for key in grp_stats['stf_time'].keys():
+                    self.source_stats['stf_time'][key] = grp_stats['stf_time'][key][:]
+                
+                self.source_stats['spectrum_octave'] = {}
+                for key in grp_stats['spectrum_octave'].keys():
+                    self.source_stats['spectrum_octave'][key] = grp_stats['spectrum_octave'][key][:]
+            
+            # Load parameters
+            grp_params = f['parameters']
+            self.params = {}
+            for key in grp_params.attrs.keys():
+                self.params[key] = grp_params.attrs[key]
+            for key in grp_params.keys():
+                if key != 'crust_model':  # Skip crust_model group
+                    self.params[key] = grp_params[key][:].tolist()
+            
+            # Reconstruct subfault geometry attributes
+            self.dx = self.params['dx']
+            self.dy = self.params['dy']
+            self.area = self.params['area']
+            self.output_name = self.params.get('output_name', 'FFSP_OUTPUT')
+            self.verbose = True  # Default
+            
+            # Load crust model - reconstruct layer by layer
+            grp_crust = grp_params['crust_model']
+            from .crustmodel import CrustModel
+            
+            nlayers = grp_crust.attrs['nlayers']
+            self.crust_model = CrustModel(nlayers)
+            
+            # Add each layer
+            d = grp_crust['d'][:]
+            a = grp_crust['a'][:]    # vp
+            b = grp_crust['b'][:]    # vs
+            rho = grp_crust['rho'][:]
+            qa = grp_crust['qa'][:]
+            qb = grp_crust['qb'][:]
+            
+            for i in range(nlayers):
+                self.crust_model.add_layer(d[i], a[i], b[i], rho[i], qa[i], qb[i])
+            
+            # Set active realization
+            self.subfaults = self.best_realization
+            self.active_realization = 'best'
+            # Detect MPI rank
+            try:
+                from mpi4py import MPI
+                rank = MPI.COMM_WORLD.Get_rank()
+            except (ImportError, AttributeError):
+                rank = 0
+
+            if rank == 0:
+                print(f"HDF5 loaded")
+                print(f"Best realization activated\n")
+
+        
+        print(f"[OK] HDF5 loaded\n")
+    
+    @classmethod
+    def from_hdf5(cls, filename: str):
+        """
+        Create FFSPSource object from HDF5 file (class method).
+        This is the recommended way to load saved results.
+        
+        Parameters
+        ----------
+        filename : str
+            Input HDF5 filename
+            
+        Returns
+        -------
+        FFSPSource
+            Fully initialized FFSPSource object with all data loaded
+            
+        Examples
+        --------
+        >>> # Save results
+        >>> source.run()
+        >>> source.write_hdf5('results.h5')
+        >>> 
+        >>> # Load in new session
+        >>> source = FFSPSource.from_hdf5('results.h5')
+        >>> source.plot_spectral_comparison()
+        """
+        
+        try:
+            import h5py
+        except ImportError:
+            raise ImportError("h5py required for HDF5 input. Install with: pip install h5py")
+        
+        if not filename.endswith('.h5'):
+            filename += '.h5'
+        
+        with h5py.File(filename, 'r') as f:
+            # Load parameters first
+            grp_params = f['parameters']
+            params = {}
+            for key in grp_params.attrs.keys():
+                params[key] = grp_params.attrs[key]
+            for key in grp_params.keys():
+                if key != 'crust_model':
+                    params[key] = grp_params[key][:].tolist()
+            
+            # Load crust model - reconstruct layer by layer
+            grp_crust = grp_params['crust_model']
+            from .crustmodel import CrustModel
+            
+            nlayers = grp_crust.attrs['nlayers']
+            crust_model = CrustModel(nlayers)
+            
+            # Add each layer
+            d = grp_crust['d'][:]
+            a = grp_crust['a'][:]    # vp
+            b = grp_crust['b'][:]    # vs
+            rho = grp_crust['rho'][:]
+            qa = grp_crust['qa'][:]
+            qb = grp_crust['qb'][:]
+            
+            for i in range(nlayers):
+                crust_model.add_layer(d[i], a[i], b[i], rho[i], qa[i], qb[i])
+        
+        # Create object using __init__ with loaded parameters
+        obj = cls(
+            id_sf_type=params['id_sf_type'],
+            freq_min=params['freq_min'],
+            freq_max=params['freq_max'],
+            fault_length=params['fault_length'],
+            fault_width=params['fault_width'],
+            x_hypc=params['x_hypc'],
+            y_hypc=params['y_hypc'],
+            depth_hypc=params['depth_hypc'],
+            xref_hypc=params['xref_hypc'],
+            yref_hypc=params['yref_hypc'],
+            magnitude=params['magnitude'],
+            fc_main_1=params['fc_main_1'],
+            fc_main_2=params['fc_main_2'],
+            rv_avg=params['rv_avg'],
+            ratio_rise=params['ratio_rise'],
+            strike=params['strike'],
+            dip=params['dip'],
+            rake=params['rake'],
+            pdip_max=params['pdip_max'],
+            prake_max=params['prake_max'],
+            nsubx=params['nsubx'],
+            nsuby=params['nsuby'],
+            nb_taper_trbl=params['nb_taper_trbl'],
+            seeds=params['seeds'],
+            id_ran1=params['id_ran1'],
+            id_ran2=params['id_ran2'],
+            angle_north_to_x=params['angle_north_to_x'],
+            is_moment=params['is_moment'],
+            crust_model=crust_model,
+            output_name=params.get('output_name', 'FFSP_OUTPUT'),
+            verbose=False  # Don't print during load
+        )
+        
+        # Now load the data into the initialized object
+        obj.load_hdf5(filename)
+        
+        return obj
+    
+    def write_ffsp_format(self, output_dir: str, output_name: str = None):
+            """
+            Write FFSP results to legacy format files.
+            
+            Creates the following files:
+            - FFSP_OUTPUT.001, .002, ... (all realizations)
+            - FFSP_OUTPUT.bst (best realization)
+            - source_model.score (quality metrics)
+            - source_model.list (geometry summary)
+            - source_model.params (all parameters)
+            - ffsp.inp (input parameters for Fortran)
+            - velocity.vel (crustal velocity model)
+            - calsvf.dat, calsvf_tim.dat, logsvf.dat (spectral data)
+            
+            Parameters
+            ----------
+            output_dir : str
+                Output directory path
+            output_name : str, optional
+                Base name for output files (default: self.output_name)
+            """
+            if self.all_realizations is None:
+                raise RuntimeError("No realizations available. Run FFSP first.")
+            
+            if output_name is None:
+                output_name = self.output_name
+            
+            os.makedirs(output_dir, exist_ok=True)
+            print(f"Writing FFSP: {output_dir}")
+            
+            n = self.all_realizations['n_realizations']
+            npts = self.all_realizations['npts']
+            
+            # =========================================================================
+            # Write realization files (.001, .002, ...)
+            # =========================================================================
+            for i in range(n):
+                filename = os.path.join(output_dir, f"{output_name}.{i+1:03d}")
+                with open(filename, 'w') as f:
+                    # Header: is_moment npts id_sf_type ratio_rise (Fortran line 210)
+                    f.write(f"{self.params['is_moment']} {npts} {self.params['id_sf_type']} {self.params['ratio_rise']}\n")
+                    
+                    # Subfault data (Fortran lines 238-239)
+                    for j in range(npts):
+                        f.write(f"{self.all_realizations['x'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['y'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['z'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['slip'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['rupture_time'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['rise_time'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['peak_time'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['strike'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['dip'][j, i]:15.6e} ")
+                        f.write(f"{self.all_realizations['rake'][j, i]:15.6e}\n")
+            
+            # =========================================================================
+            # Write best realization (.bst)
+            # =========================================================================
+            if self.best_realization is not None:
+                filename = os.path.join(output_dir, f"{output_name}.bst")
+                with open(filename, 'w') as f:
+                    # Header: is_moment npts id_sf_type ratio_rise
+                    f.write(f"{self.params['is_moment']} {self.best_realization['npts']} {self.params['id_sf_type']} {self.params['ratio_rise']}\n")
+                    
+                    # Subfault data
+                    for j in range(self.best_realization['npts']):
+                        f.write(f"{self.best_realization['x'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['y'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['z'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['slip'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['rupture_time'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['rise_time'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['peak_time'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['strike'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['dip'][j]:15.6e} ")
+                        f.write(f"{self.best_realization['rake'][j]:15.6e}\n")
+            
+            # =========================================================================
+            # Write source_model.score (quality metrics)
+            # =========================================================================
+            if self.source_stats is not None:
+                filename = os.path.join(output_dir, "source_model.score")
+                stats = self.source_stats['source_score']
+                with open(filename, 'w') as f:
+                    f.write(f"{n}\n")
+                    f.write("Target: average Risetime= 0.0 average peaktime= 0.0\n")
+                    for i in range(n):
+                        f.write(f"{output_name}.{i+1:03d}\n")
+                        f.write(f"{stats['ave_tr'][i]:15.5e} ")
+                        f.write(f"{stats['ave_tp'][i]:15.5e} ")
+                        f.write(f"{stats['ave_vr'][i]:15.5e} ")
+                        f.write(f"{stats['err_spectra'][i]:15.5e} ")
+                        f.write(f"{stats['pdf'][i]:15.5e}\n")
+            
+            # =========================================================================
+            # Write source_model.list (geometry summary)
+            # =========================================================================
+            filename = os.path.join(output_dir, "source_model.list")
+            with open(filename, 'w') as f:
+                f.write(f"{self.params['id_sf_type']} ")
+                f.write(f"{self.params['nsubx']} ")
+                f.write(f"{self.params['nsuby']} ")
+                f.write(f"{self.dx} ")
+                f.write(f"{self.dy} ")
+                f.write(f"{self.params['x_hypc']} ")
+                f.write(f"{self.params['y_hypc']}\n")
+                f.write(f"{self.params['xref_hypc']} ")
+                f.write(f"{self.params['yref_hypc']} ")
+                f.write(f"{self.params['angle_north_to_x']}\n")
+                f.write(f"{output_name}.bst\n")
+            
+            # =========================================================================
+            # Write source_model.params (all parameters - Python format)
+            # =========================================================================
+            filename = os.path.join(output_dir, "source_model.params")
+            with open(filename, 'w') as f:
+                for key, val in self.params.items():
+                    if isinstance(val, list):
+                        f.write(f"{key} {' '.join(map(str, val))}\n")
+                    else:
+                        f.write(f"{key} {val}\n")
+            
+            # =========================================================================
+            # Write ffsp.inp (Fortran input format - 16 lines)
+            # =========================================================================
+            filename = os.path.join(output_dir, "ffsp.inp")
+            with open(filename, 'w') as f:
+                # Line 1: id_sf_type freq_min freq_max
+                f.write(f"{self.params['id_sf_type']} {self.params['freq_min']} {self.params['freq_max']}\n")
+                
+                # Line 2: fault_length fault_width
+                f.write(f"{self.params['fault_length']} {self.params['fault_width']}\n")
+                
+                # Line 3: x_hypc y_hypc depth_hypc
+                f.write(f"{self.params['x_hypc']} {self.params['y_hypc']} {self.params['depth_hypc']}\n")
+                
+                # Line 4: xref_hypc yref_hypc
+                f.write(f"{self.params['xref_hypc']} {self.params['yref_hypc']}\n")
+                
+                # Line 5: magnitude fc_main_1 fc_main_2 rv_avg
+                f.write(f"{self.params['magnitude']} {self.params['fc_main_1']} {self.params['fc_main_2']} {self.params['rv_avg']}\n")
+                
+                # Line 6: ratio_rise
+                f.write(f"{self.params['ratio_rise']}\n")
+                
+                # Line 7: strike dip rake
+                f.write(f"{self.params['strike']} {self.params['dip']} {self.params['rake']}\n")
+                
+                # Line 8: pdip_max prake_max
+                f.write(f"{self.params['pdip_max']} {self.params['prake_max']}\n")
+                
+                # Line 9: nsubx nsuby
+                f.write(f"{self.params['nsubx']} {self.params['nsuby']}\n")
+                
+                # Line 10: nb_taper_trbl[0-3]
+                f.write(f"{self.params['nb_taper_trbl'][0]} {self.params['nb_taper_trbl'][1]} ")
+                f.write(f"{self.params['nb_taper_trbl'][2]} {self.params['nb_taper_trbl'][3]}\n")
+                
+                # Line 11: seeds[0-2]
+                f.write(f"{self.params['seeds'][0]} {self.params['seeds'][1]} {self.params['seeds'][2]}\n")
+                
+                # Line 12: id_ran1 id_ran2
+                f.write(f"{self.params['id_ran1']} {self.params['id_ran2']}\n")
+                
+                # Line 13: velocity_filename
+                f.write(f"velocity.vel\n")
+                
+                # Line 14: angle_north_to_x
+                f.write(f"{self.params['angle_north_to_x']}\n")
+                
+                # Line 15: is_moment
+                f.write(f"{self.params['is_moment']}\n")
+                
+                # Line 16: output_name
+                f.write(f"{output_name}\n")
+            
+            # =========================================================================
+            # Write velocity.vel (crustal model - FORMAT: vp vs rho thickness qa qb)
+            # =========================================================================
+            filename = os.path.join(output_dir, "velocity.vel")
+            with open(filename, 'w') as f:
+                # Line 1: nlayers dmin_source
+                f.write(f"{self.crust_model.nlayers} 2.0\n")
+                
+                # Lines 2+: vp vs rho thickness qa qb (NOT thickness vp vs...)
+                for i in range(self.crust_model.nlayers):
+                    f.write(f"{self.crust_model.a[i]:.6e} ")   # vp
+                    f.write(f"{self.crust_model.b[i]:.6e} ")   # vs
+                    f.write(f"{self.crust_model.rho[i]:.6e} ") # rho
+                    f.write(f"{self.crust_model.d[i]:.6e} ")   # thickness
+                    f.write(f"{self.crust_model.qa[i]:.6e} ")  # qa
+                    f.write(f"{self.crust_model.qb[i]:.6e}\n") # qb
+            
+            # =========================================================================
+            # Write spectral data files (if available)
+            # =========================================================================
+            if self.source_stats and 'spectrum' in self.source_stats:
+                # calsvf.dat (frequency spectrum)
+                filename = os.path.join(output_dir, "calsvf.dat")
+                spectrum = self.source_stats['spectrum']
+                with open(filename, 'w') as f:
+                    f.write(f"{len(spectrum['freq'])}\n")
+                    for i in range(len(spectrum['freq'])):
+                        f.write(f"{spectrum['freq'][i]:15.6e} ")
+                        f.write(f"{spectrum['moment_rate_synth'][i]:15.6e} ")
+                        f.write(f"{spectrum['moment_rate_dcf'][i]:15.6e}\n")
+                
+                # calsvf_tim.dat (time domain STF)
+                filename = os.path.join(output_dir, "calsvf_tim.dat")
+                stf = self.source_stats['stf_time']
+                with open(filename, 'w') as f:
+                    f.write(f"{len(stf['time'])}\n")
+                    for i in range(len(stf['time'])):
+                        f.write(f"{stf['time'][i]:15.6e} ")
+                        f.write(f"{stf['stf'][i]:15.6e}\n")
+                
+                # logsvf.dat (octave-averaged spectrum)
+                filename = os.path.join(output_dir, "logsvf.dat")
+                octave = self.source_stats['spectrum_octave']
+                with open(filename, 'w') as f:
+                    f.write(f"{len(octave['freq_center'])}\n")
+                    for i in range(len(octave['freq_center'])):
+                        f.write(f"{octave['freq_center'][i]:15.6e} ")
+                        f.write(f"{octave['logmean_synth'][i]:15.6e} ")
+                        f.write(f"{octave['logmean_dcf'][i]:15.6e}\n")
+            
+            print(f"[OK] FFSP saved\n")
+
+
+
+    def load_ffsp_format(self, input_dir: str, output_name: str = "FFSP_OUTPUT"):
+        """
+        Load FFSP results from modern format files (with source_model.params).
+        
+        Reads the following files:
+        - source_model.params (all parameters)
+        - velocity.vel (crustal velocity model)
+        - source_model.score (quality metrics)
+        - FFSP_OUTPUT.001, .002, ... (all realizations)
+        - FFSP_OUTPUT.bst (best realization)
+        - calsvf.dat, calsvf_tim.dat, logsvf.dat (spectral data, if available)
+        
+        Parameters
+        ----------
+        input_dir : str
+            Directory containing FFSP files
+        output_name : str, optional
+            Base name of FFSP files (default: "FFSP_OUTPUT")
+        """
+        print(f"Loading FFSP: {input_dir}")
+        
+        # =========================================================================
+        # Read source_model.params
+        # =========================================================================
+        params_file = os.path.join(input_dir, "source_model.params")
+        params = {}
+        with open(params_file, 'r') as f:
+            for line in f:
+                parts = line.strip().split()
+                key = parts[0]
+                if key in ['nb_taper_trbl', 'seeds']:
+                    params[key] = [int(x) for x in parts[1:]]
+                elif key in ['id_sf_type', 'nsubx', 'nsuby', 'id_ran1', 'id_ran2', 'is_moment']:
+                    params[key] = int(parts[1])
+                elif key == 'output_name':
+                    params[key] = parts[1]
+                else:
+                    params[key] = float(parts[1])
+        
+        self.params = params
+        self.dx = params['fault_length'] / params['nsubx']
+        self.dy = params['fault_width'] / params['nsuby']
+        self.area = self.dx * self.dy
+        self.output_name = params.get('output_name', 'FFSP_OUTPUT')
+        self.verbose = True
+        
+        # =========================================================================
+        # Read velocity.vel (FORMAT: vp vs rho thickness qa qb)
+        # =========================================================================
+        vel_file = None
+        for filename in os.listdir(input_dir):
+            if filename.endswith('.vel'):
+                vel_file = os.path.join(input_dir, filename)
+                if self.verbose:
+                    print(f"  Found velocity file: {filename}")
+                break
+
+        if vel_file is None:
+            raise FileNotFoundError(f"No .vel velocity file found in {input_dir}")
+        from .crustmodel import CrustModel
+        with open(vel_file, 'r') as f:
+            line = f.readline().strip().split()
+            nlayers = int(line[0])  # First number only
+            self.crust_model = CrustModel(nlayers)
+            for i in range(nlayers):
+                values = f.readline().split()
+                # Format: vp vs rho thickness qa qb
+                self.crust_model.add_layer(
+                    float(values[3]),  # thickness
+                    float(values[0]),  # vp
+                    float(values[1]),  # vs
+                    float(values[2]),  # rho
+                    float(values[4]),  # qa
+                    float(values[5])   # qb
+                )
+        
+        # =========================================================================
+        # Read source_model.score
+        # =========================================================================
+        score_file = os.path.join(input_dir, "source_model.score")
+        with open(score_file, 'r') as f:
+            n_realizations = int(f.readline().strip())
+            f.readline()  # Skip header line
+            ave_tr, ave_tp, ave_vr, err_spectra, pdf = [], [], [], [], []
+            for i in range(n_realizations):
+                f.readline()  # Skip filename line
+                values = f.readline().split()
+                ave_tr.append(float(values[0]))
+                ave_tp.append(float(values[1]))
+                ave_vr.append(float(values[2]))
+                err_spectra.append(float(values[3]))
+                pdf.append(float(values[4]))
+        
+        # =========================================================================
+        # Read realization files (.001, .002, ...)
+        # =========================================================================
+        npts = int(params['nsubx']) * int(params['nsuby'])
+        x = np.zeros((npts, n_realizations))
+        y = np.zeros((npts, n_realizations))
+        z = np.zeros((npts, n_realizations))
+        slip = np.zeros((npts, n_realizations))
+        rupture_time = np.zeros((npts, n_realizations))
+        rise_time = np.zeros((npts, n_realizations))
+        peak_time = np.zeros((npts, n_realizations))
+        strike = np.zeros((npts, n_realizations))
+        dip = np.zeros((npts, n_realizations))
+        rake = np.zeros((npts, n_realizations))
+        
+        for i in range(n_realizations):
+            filename = os.path.join(input_dir, f"{output_name}.{i+1:03d}")
+            with open(filename, 'r') as f:
+                header = f.readline().split()
+                # Header is: is_moment npts id_sf_type ratio_rise
+                # We extract is_moment (for legacy compatibility check)
+                is_moment = int(header[0])
+                
+                # Read subfault data
+                for j in range(npts):
+                    values = f.readline().split()
+                    x[j, i] = float(values[0])
+                    y[j, i] = float(values[1])
+                    z[j, i] = float(values[2])
+                    slip[j, i] = float(values[3])
+                    rupture_time[j, i] = float(values[4])
+                    rise_time[j, i] = float(values[5])
+                    peak_time[j, i] = float(values[6])
+                    strike[j, i] = float(values[7])
+                    dip[j, i] = float(values[8])
+                    rake[j, i] = float(values[9])
+        
+        self.all_realizations = {
+            'n_realizations': n_realizations, 
+            'nseg': 1,  # Always 1 for single-segment faults
+            'npts': npts,
+            'x': x, 'y': y, 'z': z, 
+            'slip': slip, 
+            'rupture_time': rupture_time,
+            'rise_time': rise_time, 
+            'peak_time': peak_time, 
+            'strike': strike,
+            'dip': dip, 
+            'rake': rake,
+        }
+        
+        # =========================================================================
+        # Read best realization (.bst)
+        # =========================================================================
+        best_file = os.path.join(input_dir, f"{output_name}.bst")
+        best_x, best_y, best_z = np.zeros(npts), np.zeros(npts), np.zeros(npts)
+        best_slip, best_rupture_time, best_rise_time = np.zeros(npts), np.zeros(npts), np.zeros(npts)
+        best_peak_time, best_strike, best_dip, best_rake = np.zeros(npts), np.zeros(npts), np.zeros(npts), np.zeros(npts)
+        
+        with open(best_file, 'r') as f:
+            f.readline()  # Skip header
+            for j in range(npts):
+                values = f.readline().split()
+                best_x[j], best_y[j], best_z[j] = float(values[0]), float(values[1]), float(values[2])
+                best_slip[j], best_rupture_time[j], best_rise_time[j] = float(values[3]), float(values[4]), float(values[5])
+                best_peak_time[j], best_strike[j], best_dip[j], best_rake[j] = float(values[6]), float(values[7]), float(values[8]), float(values[9])
+        
+        self.best_realization = {
+            'nseg': 1, 
+            'npts': npts, 
+            'x': best_x, 'y': best_y, 'z': best_z,
+            'slip': best_slip, 
+            'rupture_time': best_rupture_time, 
+            'rise_time': best_rise_time,
+            'peak_time': best_peak_time, 
+            'strike': best_strike, 
+            'dip': best_dip, 
+            'rake': best_rake,
+        }
+        
+        # =========================================================================
+        # Store statistics
+        # =========================================================================
+        self.source_stats = {
+            'source_score': {
+                'n_realizations': n_realizations,
+                'ave_tr': np.array(ave_tr), 
+                'ave_tp': np.array(ave_tp), 
+                'ave_vr': np.array(ave_vr),
+                'err_spectra': np.array(err_spectra), 
+                'pdf': np.array(pdf),
+            }
+        }
+        
+        # =========================================================================
+        # Read spectral data (if available)
+        # =========================================================================
+        calsvf_file = os.path.join(input_dir, "calsvf.dat")
+        if os.path.exists(calsvf_file):
+            with open(calsvf_file, 'r') as f:
+                nphf_spec = int(f.readline().strip())
+                freq_spec, moment_rate, dcf = np.zeros(nphf_spec), np.zeros(nphf_spec), np.zeros(nphf_spec)
+                for i in range(nphf_spec):
+                    values = f.readline().split()
+                    freq_spec[i], moment_rate[i], dcf[i] = float(values[0]), float(values[1]), float(values[2])
+            self.source_stats['spectrum'] = {
+                'freq': freq_spec, 
+                'moment_rate_synth': moment_rate, 
+                'moment_rate_dcf': dcf
+            }
+            
+            # calsvf_tim.dat
+            calsvf_tim = os.path.join(input_dir, "calsvf_tim.dat")
+            if os.path.exists(calsvf_tim):
+                with open(calsvf_tim, 'r') as f:
+                    ntime_spec = int(f.readline().strip())
+                    time, stf = np.zeros(ntime_spec), np.zeros(ntime_spec)
+                    for i in range(ntime_spec):
+                        values = f.readline().split()
+                        time[i], stf[i] = float(values[0]), float(values[1])
+                self.source_stats['stf_time'] = {'time': time, 'stf': stf}
+            
+            # logsvf.dat
+            logsvf = os.path.join(input_dir, "logsvf.dat")
+            if os.path.exists(logsvf):
+                with open(logsvf, 'r') as f:
+                    lnpt_spec = int(f.readline().strip())
+                    freq_center, logmean_synth, logmean_dcf = np.zeros(lnpt_spec), np.zeros(lnpt_spec), np.zeros(lnpt_spec)
+                    for i in range(lnpt_spec):
+                        values = f.readline().split()
+                        freq_center[i], logmean_synth[i], logmean_dcf[i] = float(values[0]), float(values[1]), float(values[2])
+                self.source_stats['spectrum_octave'] = {
+                    'freq_center': freq_center, 
+                    'logmean_synth': logmean_synth, 
+                    'logmean_dcf': logmean_dcf
+                }
+        
+        # Set active realization
+        self.subfaults = self.best_realization
+        self.active_realization = 'best'
+        # Detect MPI rank
+        try:
+            from mpi4py import MPI
+            rank = MPI.COMM_WORLD.Get_rank()
+        except (ImportError, AttributeError):
+            rank = 0
+
+        if self.verbose and rank == 0:
+            print(f"[OK] FFSP loaded")
+            print(f"Best realization activated\n")
+        print(f"[OK] FFSP loaded\n")
+
+
+    @classmethod
+    def from_ffsp_format(cls, input_dir: str, output_name: str = "FFSP_OUTPUT", verbose: bool = True):
+         """
+         Load FFSP results from directory.
+         Works with both Python-generated and original Fortran FFSP output.
+         
+         For Fortran output, requires ffsp.inp to be present in the directory.
+         """
+         
+         params_file = os.path.join(input_dir, "source_model.params")
+         
+         if os.path.exists(params_file):
+             # Python-generated format (has .params file)
+             if verbose:
+                 print(f"Loading Python-generated FFSP output")
+             return cls._load_from_params_file(input_dir, output_name, verbose)
+         else:
+             # Original Fortran format (needs ffsp.inp)
+             inp_file = os.path.join(input_dir, "ffsp.inp")
+             if not os.path.exists(inp_file):
+                 raise FileNotFoundError(
+                     f"Cannot load FFSP data from {input_dir}\n\n"
+                     f"Missing required files:\n"
+                     f"  - source_model.params (Python format), OR\n"
+                     f"  - ffsp.inp (Fortran format)\n\n"
+                     f"At least one of these files must be present to reconstruct the source model."
+                 )
+             
+             if verbose:
+                 print(f"Loading original Fortran FFSP output")
+             return cls._load_from_fortran_files(input_dir, output_name, verbose)
+
+    @classmethod
+    def _load_from_params_file(cls, input_dir: str, output_name: str, verbose: bool):
+         """Load from Python-generated format with source_model.params"""
+         
+         # Read params
+         params_file = os.path.join(input_dir, "source_model.params")
+         params = {}
+         
+         with open(params_file, 'r') as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) >= 2:
+                    key = parts[0]
+                    if key in ['id_sf_type', 'nsubx', 'nsuby', 'id_ran1', 'id_ran2', 'is_moment']:
+                        params[key] = int(parts[1])
+                    elif key == 'nb_taper_trbl':
+                        params[key] = [int(x) for x in parts[1:5]]
+                    elif key == 'seeds':
+                        params[key] = [int(x) for x in parts[1:4]]
+                    elif key == 'output_name':
+                        params[key] = parts[1]
+                    else:
+                        params[key] = float(parts[1])
+         
+         # Load velocity model
+         vel_file = None
+         for filename in os.listdir(input_dir):
+            if filename.endswith('.vel'):
+                vel_file = os.path.join(input_dir, filename)
+                if verbose:
+                    print(f"  Found velocity file: {filename}")
+                break
+
+         if vel_file is None:
+            raise FileNotFoundError(f"No .vel velocity file found in {input_dir}")
+
+         with open(vel_file, 'r') as f:
+            line = f.readline().strip().split()
+            nlayers = int(line[0])
+            crust_model = CrustModel(nlayers)
+            for i in range(nlayers):
+                values = f.readline().split()
+                # Format: vp vs rho thickness qa qb
+                crust_model.add_layer(
+                    float(values[3]),  # thickness
+                    float(values[0]),  # vp
+                    float(values[1]),  # vs
+                    float(values[2]),  # rho
+                    float(values[4]),  # qa
+                    float(values[5])   # qb
+                )
+         
+         # Create FFSPSource object
+         source = cls(
+             id_sf_type=params['id_sf_type'],
+             freq_min=params['freq_min'],
+             freq_max=params['freq_max'],
+             fault_length=params['fault_length'],
+             fault_width=params['fault_width'],
+             x_hypc=params['x_hypc'],
+             y_hypc=params['y_hypc'],
+             depth_hypc=params['depth_hypc'],
+             xref_hypc=params['xref_hypc'],
+             yref_hypc=params['yref_hypc'],
+             magnitude=params['magnitude'],
+             fc_main_1=params['fc_main_1'],
+             fc_main_2=params['fc_main_2'],
+             rv_avg=params['rv_avg'],
+             ratio_rise=params['ratio_rise'],
+             strike=params['strike'],
+             dip=params['dip'],
+             rake=params['rake'],
+             pdip_max=params['pdip_max'],
+             prake_max=params['prake_max'],
+             nsubx=params['nsubx'],
+             nsuby=params['nsuby'],
+             nb_taper_trbl=params['nb_taper_trbl'],
+             seeds=params['seeds'],
+             id_ran1=params['id_ran1'],
+             id_ran2=params['id_ran2'],
+             angle_north_to_x=params['angle_north_to_x'],
+             is_moment=params['is_moment'],
+             crust_model=crust_model,
+             output_name=params.get('output_name', output_name),
+             verbose=verbose
+         )
+         
+         # Load data files using existing method
+         source._load_ffsp_data_legacy(input_dir, output_name)
+         
+         return source
+
+    @classmethod
+    def _load_from_fortran_files(cls, input_dir: str, output_name: str, verbose: bool):
+         """Reconstruct FFSPSource from original Fortran FFSP output files"""
+         
+         # 1. Parse ffsp.inp
+         inp_file = os.path.join(input_dir, "ffsp.inp")
+         params = cls._parse_ffsp_inp(inp_file)
+         
+         # 2. Read source_model.list for geometric info
+         list_file = os.path.join(input_dir, "source_model.list")
+         with open(list_file, 'r') as f:
+             lines = f.readlines()
+             parts = lines[0].strip().split()
+             nsubx = int(parts[1])
+             nsuby = int(parts[2])
+         
+         # 3. Count realizations
+         id_ran1 = 1
+         id_ran2 = 1
+         while os.path.exists(os.path.join(input_dir, f"{output_name}.{id_ran2:03d}")):
+             id_ran2 += 1
+         id_ran2 -= 1
+         
+         if verbose:
+             print(f"  Found {id_ran2} realizations")
+             print(f"  Grid: {nsubx} × {nsuby} subfaults")
+         
+         # 4. Load velocity model
+         vel_file = None
+         for filename in os.listdir(input_dir):
+            if filename.endswith('.vel'):
+                vel_file = os.path.join(input_dir, filename)
+                if verbose:
+                    print(f"  Found velocity file: {filename}")
+                break
+
+         if vel_file is None:
+            raise FileNotFoundError(f"No .vel velocity file found in {input_dir}")
+         with open(vel_file, 'r') as f:
+            line = f.readline().strip().split()
+            nlayers = int(line[0])
+            crust_model = CrustModel(nlayers)
+            for i in range(nlayers):
+                values = f.readline().split()
+                # Format: vp vs rho thickness qa qb
+                crust_model.add_layer(
+                    float(values[3]),  # thickness
+                    float(values[0]),  # vp
+                    float(values[1]),  # vs
+                    float(values[2]),  # rho
+                    float(values[4]),  # qa
+                    float(values[5])   # qb
+                )
+         
+         # 5. Create FFSPSource
+         source = cls(
+             id_sf_type=params['id_sf_type'],
+             freq_min=0.0,
+             freq_max=params['freq_max'],
+             fault_length=params['fault_length'],
+             fault_width=params['fault_width'],
+             x_hypc=params['x_hypc'],
+             y_hypc=params['y_hypc'],
+             depth_hypc=params['depth_hypc'],
+             xref_hypc=params['xref_hypc'],
+             yref_hypc=params['yref_hypc'],
+             magnitude=params['magnitude'],
+             fc_main_1=params['fc_main_1'],
+             fc_main_2=params['fc_main_2'],
+             rv_avg=params['rv_avg'],
+             ratio_rise=params['ratio_rise'],
+             strike=params['strike'],
+             dip=params['dip'],
+             rake=params['rake'],
+             pdip_max=params['pdip_max'],
+             prake_max=params['prake_max'],
+             nsubx=nsubx,
+             nsuby=nsuby,
+             nb_taper_trbl=params['nb_taper_trbl'],
+             seeds=params['seeds'],
+             id_ran1=id_ran1,
+             id_ran2=id_ran2,
+             angle_north_to_x=params['angle_north_to_x'],
+             is_moment=params['is_moment'],
+             crust_model=crust_model,
+             output_name=output_name,
+             verbose=verbose
+         )
+         
+         # 6. Load data files using existing method
+         source._load_ffsp_data_legacy(input_dir, output_name)
+         
+         return source
+
+    @staticmethod
+    def _parse_ffsp_inp(inp_file: str) -> dict:
+         """Parse ffsp.inp - extracts ALL parameters from original Fortran input"""
+         
+         with open(inp_file, 'r') as f:
+             lines = f.readlines()
+         
+         params = {}
+         
+         # Line 1: id_sf_type freq_max
+         parts = lines[0].strip().split()
+         params['id_sf_type'] = int(parts[0])
+         params['freq_max'] = float(parts[1])
+         
+         # Line 2: fault_length fault_width
+         parts = lines[1].strip().split()
+         params['fault_length'] = float(parts[0])
+         params['fault_width'] = float(parts[1])
+         
+         # Line 3: x_hypc y_hypc depth_hypc
+         parts = lines[2].strip().split()
+         params['x_hypc'] = float(parts[0])
+         params['y_hypc'] = float(parts[1])
+         params['depth_hypc'] = float(parts[2])
+         
+         # Line 4: xref_hypc yref_hypc
+         parts = lines[3].strip().split()
+         params['xref_hypc'] = float(parts[0])
+         params['yref_hypc'] = float(parts[1])
+         
+         # Line 5: moment fc_main_1 fc_main_2 rv_avg
+         parts = lines[4].strip().split()
+         params['magnitude'] = float(parts[0])
+         params['fc_main_1'] = float(parts[1])
+         params['fc_main_2'] = float(parts[2])
+         params['rv_avg'] = float(parts[3])
+         
+         # Line 6: ratio_rise
+         params['ratio_rise'] = float(lines[5].strip())
+         
+         # Line 7: strike dip rake
+         parts = lines[6].strip().split()
+         params['strike'] = float(parts[0])
+         params['dip'] = float(parts[1])
+         params['rake'] = float(parts[2])
+         
+         # Line 8: pdip_max prake_max
+         parts = lines[7].strip().split()
+         params['pdip_max'] = float(parts[0])
+         params['prake_max'] = float(parts[1])
+         
+         # Line 9: nsubx nsuby (also in .list, but read from both)
+         parts = lines[8].strip().split()
+         params['nsubx'] = int(parts[0])
+         params['nsuby'] = int(parts[1])
+         
+         # Line 10: nb_taper_TRBL
+         parts = lines[9].strip().split()
+         params['nb_taper_trbl'] = [int(x) for x in parts]
+         
+         # Line 11: seeds
+         parts = lines[10].strip().split()
+         params['seeds'] = [int(x) for x in parts]
+         
+         # Line 12: id_ran1 id_ran2 (counted from output files)
+         parts = lines[11].strip().split()
+         params['id_ran1'] = int(parts[0])
+         params['id_ran2'] = int(parts[1])
+         
+         # Line 14: angle_north_to_x
+         params['angle_north_to_x'] = float(lines[13].strip())
+         
+         # Line 15: is_moment
+         params['is_moment'] = int(lines[14].strip())
+         
+         return params
+
+    def _load_ffsp_data_legacy(self, input_dir: str, output_name: str):
+        """Helper to load FFSP data files for legacy format"""
+        
+        # =========================================================================
+        # Read source_model.score (OPTIONAL - may not exist for single realization)
+        # =========================================================================
+        score_file = os.path.join(input_dir, "source_model.score")
+        
+        if os.path.exists(score_file):
+            # Multiple realizations case
+            with open(score_file, 'r') as f:
+                n_realizations = int(f.readline().strip())
+                f.readline()  # Skip header
+                ave_tr, ave_tp, ave_vr, err_spectra, pdf = [], [], [], [], []
+                for i in range(n_realizations):
+                    f.readline()  # Skip filename
+                    values = f.readline().split()
+                    ave_tr.append(float(values[0]))
+                    ave_tp.append(float(values[1]))
+                    ave_vr.append(float(values[2]))
+                    err_spectra.append(float(values[3]))
+                    pdf.append(float(values[4]))
+        else:
+            # Single realization case - count files manually
+            n_realizations = 0
+            i = 1
+            while os.path.exists(os.path.join(input_dir, f"{output_name}.{i:03d}")):
+                n_realizations += 1
+                i += 1
+            
+            if n_realizations == 0:
+                raise FileNotFoundError(
+                    f"No realization files found in {input_dir}\n"
+                    f"Expected files: {output_name}.001, {output_name}.002, etc."
+                )
+            
+            # Create dummy statistics (not meaningful for single realization)
+            ave_tr = [0.0] * n_realizations
+            ave_tp = [0.0] * n_realizations
+            ave_vr = [0.0] * n_realizations
+            err_spectra = [0.0] * n_realizations
+            pdf = [0.0] * n_realizations
+        
+        # =========================================================================
+        # Read realization files (.001, .002, ...)
+        # =========================================================================
+        npts = self.params['nsubx'] * self.params['nsuby']
+        x = np.zeros((npts, n_realizations))
+        y = np.zeros((npts, n_realizations))
+        z = np.zeros((npts, n_realizations))
+        slip = np.zeros((npts, n_realizations))
+        rupture_time = np.zeros((npts, n_realizations))
+        rise_time = np.zeros((npts, n_realizations))
+        peak_time = np.zeros((npts, n_realizations))
+        strike = np.zeros((npts, n_realizations))
+        dip = np.zeros((npts, n_realizations))
+        rake = np.zeros((npts, n_realizations))
+        
+        for i in range(n_realizations):
+            filename = os.path.join(input_dir, f"{output_name}.{i+1:03d}")
+            with open(filename, 'r') as f:
+                header = f.readline().split()
+                nseg = int(header[0])
+                for j in range(npts):
+                    values = f.readline().split()
+                    x[j, i] = float(values[0])
+                    y[j, i] = float(values[1])
+                    z[j, i] = float(values[2])
+                    slip[j, i] = float(values[3])
+                    rupture_time[j, i] = float(values[4])
+                    rise_time[j, i] = float(values[5])
+                    peak_time[j, i] = float(values[6])
+                    strike[j, i] = float(values[7])
+                    dip[j, i] = float(values[8])
+                    rake[j, i] = float(values[9])
+        
+        self.all_realizations = {
+            'n_realizations': n_realizations,
+            'nseg': nseg,
+            'npts': npts,
+            'x': x,
+            'y': y,
+            'z': z,
+            'slip': slip,
+            'rupture_time': rupture_time,
+            'rise_time': rise_time,
+            'peak_time': peak_time,
+            'strike': strike,
+            'dip': dip,
+            'rake': rake,
+        }
+        
+        # =========================================================================
+        # Read best realization (.bst) - OPTIONAL for single realization
+        # =========================================================================
+        best_file = os.path.join(input_dir, f"{output_name}.bst")
+        
+        if os.path.exists(best_file):
+            # .bst file exists (multiple realizations)
+            best_x = np.zeros(npts)
+            best_y = np.zeros(npts)
+            best_z = np.zeros(npts)
+            best_slip = np.zeros(npts)
+            best_rupture_time = np.zeros(npts)
+            best_rise_time = np.zeros(npts)
+            best_peak_time = np.zeros(npts)
+            best_strike = np.zeros(npts)
+            best_dip = np.zeros(npts)
+            best_rake = np.zeros(npts)
+            
+            with open(best_file, 'r') as f:
+                f.readline()  # Skip header
+                for j in range(npts):
+                    values = f.readline().split()
+                    best_x[j] = float(values[0])
+                    best_y[j] = float(values[1])
+                    best_z[j] = float(values[2])
+                    best_slip[j] = float(values[3])
+                    best_rupture_time[j] = float(values[4])
+                    best_rise_time[j] = float(values[5])
+                    best_peak_time[j] = float(values[6])
+                    best_strike[j] = float(values[7])
+                    best_dip[j] = float(values[8])
+                    best_rake[j] = float(values[9])
+            
+            self.best_realization = {
+                'nseg': nseg,
+                'npts': npts,
+                'x': best_x,
+                'y': best_y,
+                'z': best_z,
+                'slip': best_slip,
+                'rupture_time': best_rupture_time,
+                'rise_time': best_rise_time,
+                'peak_time': best_peak_time,
+                'strike': best_strike,
+                'dip': best_dip,
+                'rake': best_rake,
+            }
+        else:
+            # No .bst file - use first (and only) realization as "best"
+            self.best_realization = {
+                'nseg': nseg,
+                'npts': npts,
+                'x': x[:, 0],
+                'y': y[:, 0],
+                'z': z[:, 0],
+                'slip': slip[:, 0],
+                'rupture_time': rupture_time[:, 0],
+                'rise_time': rise_time[:, 0],
+                'peak_time': peak_time[:, 0],
+                'strike': strike[:, 0],
+                'dip': dip[:, 0],
+                'rake': rake[:, 0],
+            }
+        
+        # =========================================================================
+        # Store statistics
+        # =========================================================================
+        self.source_stats = {
+            'source_score': {
+                'n_realizations': n_realizations,
+                'ave_tr': np.array(ave_tr),
+                'ave_tp': np.array(ave_tp),
+                'ave_vr': np.array(ave_vr),
+                'err_spectra': np.array(err_spectra),
+                'pdf': np.array(pdf),
+            }
+        }
+        
+        # =========================================================================
+        # Load spectral data if available
+        # =========================================================================
+        calsvf_file = os.path.join(input_dir, "calsvf.dat")
+        if os.path.exists(calsvf_file):
+            with open(calsvf_file, 'r') as f:
+                nphf_spec = int(f.readline().strip())
+                freq_spec = np.zeros(nphf_spec)
+                moment_rate = np.zeros(nphf_spec)
+                dcf = np.zeros(nphf_spec)
+                for i in range(nphf_spec):
+                    values = f.readline().split()
+                    freq_spec[i] = float(values[0])
+                    moment_rate[i] = float(values[1])
+                    dcf[i] = float(values[2])
+            
+            self.source_stats['spectrum'] = {
+                'freq': freq_spec,
+                'moment_rate_synth': moment_rate,
+                'moment_rate_dcf': dcf
+            }
+            
+            # calsvf_tim.dat
+            calsvf_tim = os.path.join(input_dir, "calsvf_tim.dat")
+            if os.path.exists(calsvf_tim):
+                with open(calsvf_tim, 'r') as f:
+                    ntime_spec = int(f.readline().strip())
+                    time = np.zeros(ntime_spec)
+                    stf = np.zeros(ntime_spec)
+                    for i in range(ntime_spec):
+                        values = f.readline().split()
+                        time[i] = float(values[0])
+                        stf[i] = float(values[1])
+                
+                self.source_stats['stf_time'] = {
+                    'time': time,
+                    'stf': stf
+                }
+            
+            # logsvf.dat
+            logsvf = os.path.join(input_dir, "logsvf.dat")
+            if os.path.exists(logsvf):
+                with open(logsvf, 'r') as f:
+                    lnpt_spec = int(f.readline().strip())
+                    freq_center = np.zeros(lnpt_spec)
+                    logmean_synth = np.zeros(lnpt_spec)
+                    logmean_dcf = np.zeros(lnpt_spec)
+                    for i in range(lnpt_spec):
+                        values = f.readline().split()
+                        freq_center[i] = float(values[0])
+                        logmean_synth[i] = float(values[1])
+                        logmean_dcf[i] = float(values[2])
+                
+                self.source_stats['spectrum_octave'] = {
+                    'freq_center': freq_center,
+                    'logmean_synth': logmean_synth,
+                    'logmean_dcf': logmean_dcf
+                }
+        
+        # =========================================================================
+        # Set active realization
+        # =========================================================================
+        self.subfaults = self.best_realization
+        self.active_realization = 'best'
+        
+        print(f"[OK] Legacy FFSP loaded\n")
+    
+
+    # ============ PLOTTING METHODS ============
+    
+    def plot_histogram(self, field='slip', bins=50, figsize=(7, 5)):
+        """Plot histogram of field across all realizations."""
+        import matplotlib.pyplot as plt
+        valid_fields = ['x', 'y', 'z', 'slip', 'rupture_time', 'rise_time',
+                       'peak_time', 'strike', 'dip', 'rake']
+        if field not in valid_fields:
+            raise ValueError(f"field must be one of {valid_fields}, got '{field}'")
+            
+        plt.figure(figsize=figsize)
+        
+        # Plot all realizations
+        for i in range(self.all_realizations['n_realizations']):
+            var = self.all_realizations[field][:, i]
+            plt.hist(var, bins=bins, alpha=0.4, label=f'Rlz{i+1}')
+        
+        # Plot best realization
+        var_best = self.best_realization[field]
+        plt.hist(var_best, bins=bins, histtype='step', color='red', 
+                linewidth=2, label='Best')
+        
+        # Labels
+        field_labels = {
+            'x': 'North (m)', 'y': 'East (m)', 'z': 'Depth (m)',
+            'slip': 'Slip (m)', 'rupture_time': 'Rupture Time (s)',
+            'rise_time': 'Rise Time (s)', 'peak_time': 'Peak Time (s)',
+            'strike': 'Strike (°)', 'dip': 'Dip (°)', 'rake': 'Rake (°)'
+        }
+        
+        plt.xlabel(field_labels[field])
+        plt.ylabel('Frequency')
+        plt.title(f'{field_labels[field]} - Multiple Realizations')
+        plt.legend()
+        plt.grid(True, alpha=0.3)
+        plt.tight_layout()
+        plt.show()
+
+
+
+    def plot_spacial_distribution(self, figsize=(10, 8), field='rise_time', rotate=False,
+                                  cmap='coolwarm', show_contours=True, 
+                                  contour_field='rupture_time', show_hypocenter=True,
+                                  contour_interval=None, contour_color='blue',
+                                  internal_ref=None, external_coord=None,
+                                  save_fig=False, model_name='model' , image_type='png'):
+        """
+        Plot spatial distribution of subfault parameters with strike rotation.
+        """
+        
+        import matplotlib.colors as mcolors
+        import matplotlib.pyplot as plt
+
+        # Get colormap (new way)
+        cmap_base = plt.get_cmap('YlOrRd', 256)
+
+        # Create new colormap starting with white
+        colors = cmap_base(np.linspace(0, 1, 256))
+        colors[0] = [1, 1, 1, 1]  # White
+
+        cmap_white = mcolors.ListedColormap(colors)
+        if cmap == 'cmap_white':
+            cmap = cmap_white
+
+
+        nx = int(self.params['nsubx'])
+        ny = int(self.params['nsuby'])
+        lx = self.params['fault_length']
+        ly = self.params['fault_width']
+        dx = self.dx
+        dy = self.dy
+        cxp = self.params['x_hypc']
+        cyp = self.params['y_hypc']
+        strike = self.params['strike']
+        
+        # Validate fields
+        valid_fields = ['slip', 'rupture_time', 'rise_time', 'peak_time', 
+                       'strike', 'dip', 'rake']
+        if field not in valid_fields:
+            raise ValueError(f"field must be one of {valid_fields}")
+        if contour_field not in valid_fields:
+            raise ValueError(f"contour_field must be one of {valid_fields}")
+        
+        # Prepare data
+        field_data = np.transpose(self.subfaults[field].reshape(nx, ny))
+        contour_data = np.transpose(self.subfaults[contour_field].reshape(nx, ny))
+        
+        # Create local coordinates CENTERED ON HYPOCENTER
+        x_local = np.linspace(-lx/2, lx/2, nx)
+        y_local = np.linspace(0, ly, ny)
+
+        # Convert strike to radians
+        if rotate:
+            strike_rad = np.radians(strike) + np.radians(90)
+        else:
+            strike_rad = np.radians(strike)
+
+        # Create meshgrid centered on hypocenter
+        X_local, Y_local = np.meshgrid(x_local, y_local)
+
+        # Shift to center on hypocenter before rotating
+        X_centered = X_local - (cxp - lx/2)
+        Y_centered = Y_local - cyp
+
+        # Rotate around hypocenter
+        X_rot = X_centered * np.sin(strike_rad) + Y_centered * np.cos(strike_rad)
+        Y_rot = X_centered * np.cos(strike_rad) - Y_centered * np.sin(strike_rad)
+        
+        # Apply coordinate transformation if provided
+        if internal_ref is not None and external_coord is not None:
+            ref_x, ref_y = internal_ref
+            if rotate:
+                ext_y, ext_x = external_coord
+            else:
+                ext_x, ext_y = external_coord
+            
+            # Rotate the reference point
+            ref_x_rot = ref_x * np.sin(strike_rad) + ref_y * np.cos(strike_rad)
+            ref_y_rot = ref_x * np.cos(strike_rad) - ref_y * np.sin(strike_rad)
+            
+            # Calculate offset to place ref at external coord
+            offset_x = ext_x - ref_x_rot
+            offset_y = ext_y - ref_y_rot
+            
+            # Apply offset
+            X = X_rot + offset_x
+            Y = Y_rot + offset_y
+            
+            # Transform hypocenter
+            hypo_x = self.params['xref_hypc'] * np.sin(strike_rad) + self.params['yref_hypc'] * np.cos(strike_rad) + offset_x
+            hypo_y = self.params['xref_hypc'] * np.cos(strike_rad) - self.params['yref_hypc'] * np.sin(strike_rad) + offset_y
+            
+            if rotate:
+                ylabel = 'UTM Easting, X [km]'
+                xlabel = 'UTM Northing, Y [km]'
+            else:                
+                xlabel = 'UTM Easting, X [km]'
+                ylabel = 'UTM Northing, Y [km]'
+        else:
+            # No transformation, use xref/yref as offset
+            X = X_rot + self.params['xref_hypc']
+            Y = Y_rot + self.params['yref_hypc']
+            
+            hypo_x = self.params['xref_hypc']
+            hypo_y = self.params['yref_hypc']
+            
+            if rotate:
+                ylabel = 'Along Dip [km]'
+                xlabel = 'Along Strike [km]'
+            else:                
+                xlabel = 'Along Dip [km]'
+                ylabel = 'Along Strike [km]'
+        
+        # Labels
+        field_labels = {
+            'slip': 'Slip [m]', 'rupture_time': 'Rupture Time [s]',
+            'rise_time': 'Rise Time [s]', 'peak_time': 'Peak Time [s]',
+            'strike': 'Strike [°]', 'dip': 'Dip [°]', 'rake': 'Rake [°]',
+        }
+        
+        # Plot
+        fig, ax = plt.subplots(figsize=figsize)
+        
+        # Use pcolormesh for rotated coordinates
+        vmin = field_data.min()
+        vmax = field_data.max()  
+
+        im = ax.pcolormesh(X, Y, field_data, cmap=cmap, shading='auto',
+                    vmin=vmin, vmax=vmax)
+
+        if rotate:
+            from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+            divider = make_axes_locatable(ax)
+            cax = divider.append_axes("right", size="5%", pad=0.15)
+            cbar = fig.colorbar(im, cax=cax, orientation='vertical')
+            cbar.set_label(field_labels[field], fontsize=10)
+
+
+        else:
+            plt.colorbar(im, label=field_labels[field], shrink=1.0, ax=ax)
+
+        
+        # Contours
+        if show_contours:
+            if contour_interval is not None:
+                # Custom interval
+                levels = np.arange(0, contour_data.max() + contour_interval, contour_interval)
+                contours = ax.contour(X, Y, contour_data, levels=levels, colors=contour_color, linewidths=1.5)
+            else:
+                # Automatic levels
+                contours = ax.contour(X, Y, contour_data, 8, colors='blue', linewidths=1.5)
+            
+            ax.clabel(contours, fontsize=10, fmt='%2.1f', inline=1)
+            ax.plot([], [], color='blue', linewidth=1.5, label=f'Isochrones ({field_labels[contour_field]})')
+
+        # Hypocenter
+        if show_hypocenter:
+            ax.scatter(hypo_x, hypo_y, c='red', s=300, marker='*', 
+                       edgecolors='white', linewidth=2, label='Hypocenter', zorder=10)
+        
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f'{field_labels[field]} Distribution', fontsize=11, fontweight='bold')
+        ax.set_aspect('equal')
+        # Add margins to the plot (10% padding)
+        x_min, x_max = X.min(), X.max()
+        y_min, y_max = Y.min(), Y.max()
+        x_range = x_max - x_min
+        y_range = y_max - y_min
+        padding = 0.01
+
+        ax.set_xlim(x_min - padding * x_range, x_max + padding * x_range)
+        ax.set_ylim(y_min - padding * y_range, y_max + padding * y_range)
+
+        for spine in ax.spines.values():
+            spine.set_visible(True)
+
+        plt.tight_layout()
+
+        
+        # Save figure if requested
+        if save_fig:
+            plt.savefig(f'{model_name}_spatial_distribution.{image_type}', 
+                        format=image_type, 
+                        dpi=600, 
+                        bbox_inches='tight', 
+                        transparent=True,
+                        facecolor='none')
+        
+        plt.show()
+
+
+
+    def plot_rupture_snapshot(self, time_snapshot, figsize=(10, 8), 
+                             field='slip', cmap='YlOrRd',
+                             show_rupture_front=True,
+                             internal_ref=None, external_coord=None,
+                             save_fig=False, model_name='model',  image_type='png'):
+        """
+        Plot rupture propagation snapshot at a specific time.
+        """
+        
+        import matplotlib.colors as mcolors
+        import matplotlib.pyplot as plt
+        
+        # Custom colormap with white start
+        cmap_base = plt.get_cmap('YlOrRd', 256)
+        colors = cmap_base(np.linspace(0, 1, 256))
+        colors[0] = [1, 1, 1, 1]  # White
+        cmap_white = mcolors.ListedColormap(colors)
+        if cmap == 'cmap_white':
+            cmap = cmap_white
+        
+        # If cmap is still a string, create custom colormap
+        if isinstance(cmap, str):
+            cmap_base = plt.get_cmap(cmap, 256)
+            colors = cmap_base(np.linspace(0, 1, 256))
+            colors[0] = [1, 1, 1, 1]
+            cmap_custom = mcolors.ListedColormap(colors)
+        else:
+            cmap_custom = cmap
+        
+        nx = int(self.params['nsubx'])
+        ny = int(self.params['nsuby'])
+        lx = self.params['fault_length']
+        ly = self.params['fault_width']
+        cxp = self.params['x_hypc']
+        cyp = self.params['y_hypc']
+        strike = self.params['strike']
+        
+        # Get data
+        rupture_time = np.transpose(self.subfaults['rupture_time'].reshape(nx, ny))
+        field_data = np.transpose(self.subfaults[field].reshape(nx, ny))
+        
+        # Get vmin/vmax from FULL field (before masking)
+        vmin = field_data.min()
+        vmax = field_data.max()
+        
+        # NOW apply mask
+        mask = rupture_time <= time_snapshot
+        field_masked = np.ma.masked_where(~mask, field_data)
+        
+        # Coordinates
+        x_local = np.linspace(-lx/2, lx/2, nx)
+        y_local = np.linspace(0, ly, ny)
+        strike_rad = np.radians(strike)
+        X_local, Y_local = np.meshgrid(x_local, y_local)
+        
+        X_centered = X_local - (cxp - lx/2)
+        Y_centered = Y_local - cyp
+        X_rot = X_centered * np.sin(strike_rad) + Y_centered * np.cos(strike_rad)
+        Y_rot = X_centered * np.cos(strike_rad) - Y_centered * np.sin(strike_rad)
+        
+        if internal_ref is not None and external_coord is not None:
+            ref_x, ref_y = internal_ref
+            ext_x, ext_y = external_coord
+            ref_x_rot = ref_x * np.sin(strike_rad) + ref_y * np.cos(strike_rad)
+            ref_y_rot = ref_x * np.cos(strike_rad) - ref_y * np.sin(strike_rad)
+            offset_x = ext_x - ref_x_rot
+            offset_y = ext_y - ref_y_rot
+            X = X_rot + offset_x
+            Y = Y_rot + offset_y
+            hypo_x = self.params['xref_hypc'] * np.sin(strike_rad) + self.params['yref_hypc'] * np.cos(strike_rad) + offset_x
+            hypo_y = self.params['xref_hypc'] * np.cos(strike_rad) - self.params['yref_hypc'] * np.sin(strike_rad) + offset_y
+            xlabel = 'UTM Easting, X [km]'
+            ylabel = 'UTM Northing, Y [km]'
+        else:
+            X = X_rot + self.params['xref_hypc']
+            Y = Y_rot + self.params['yref_hypc']
+            hypo_x = self.params['xref_hypc']
+            hypo_y = self.params['yref_hypc']
+            xlabel = 'Along Dip [km]'
+            ylabel = 'Along Strike [km]'
+        
+        # Labels
+        field_labels = {
+            'slip': 'Slip [m]',
+            'rise_time': 'Rise Time [s]',
+            'peak_time': 'Peak Time [s]',
+        }
+        
+        # Plot
+        fig, ax = plt.subplots(figsize=figsize)
+        
+        # Gray background for unruptured areas
+        ax.set_facecolor('#E8E8E8')
+        
+        # Plot masked field with fixed vmin/vmax
+        im = ax.pcolormesh(X, Y, field_masked, cmap=cmap_custom, shading='auto',
+                           vmin=vmin, vmax=vmax)
+        cbar = plt.colorbar(im, label=field_labels[field], shrink=1.0, ax=ax)
+        
+        # Blue contour at rupture front
+        if show_rupture_front:
+            contours = ax.contour(X, Y, rupture_time, levels=[time_snapshot], 
+                                 colors='tab:blue', linewidths=2, zorder=5)
+        
+        # Hypocenter
+        ax.scatter(hypo_x, hypo_y, c='white', s=400, marker='*', 
+                   edgecolors='black', linewidth=3, label='Hypocenter', zorder=10)
+        
+        ax.legend(loc='upper right', frameon=True)
+        ax.set_xlabel(xlabel, fontsize=12)
+        ax.set_ylabel(ylabel, fontsize=12)
+        ax.set_title(f'T={time_snapshot:.2f}s', fontsize=14, fontweight='bold', loc='left')
+        ax.set_aspect('equal')
+        
+        # Margins
+        x_min, x_max = X.min(), X.max()
+        y_min, y_max = Y.min(), Y.max()
+        x_range = x_max - x_min
+        y_range = y_max - y_min
+        padding = 0.05
+        ax.set_xlim(x_min - padding * x_range, x_max + padding * x_range)
+        ax.set_ylim(y_min - padding * y_range, y_max + padding * y_range)
+        
+        for spine in ax.spines.values():
+            spine.set_visible(True)
+        
+        plt.tight_layout()
+
+        if save_fig:
+            plt.savefig(f'{model_name}_rupture_snapshot.{image_type}',
+                        format=image_type,
+                        dpi=600,
+                        bbox_inches='tight',
+                        transparent=True,
+                        facecolor='none')
+
+        plt.show()
+
+
+
+    def plot_quality_metrics(self, figsize=(14, 5)):
+        """Plot PDF and Spectral Error side by side."""
+        import matplotlib.pyplot as plt
+        if self.source_stats is None:
+            print("No source statistics available. Run simulation first.")
+            return
+            
+        stats = self.source_stats['source_score']
+        n = stats['n_realizations']
+        idx = np.arange(1, n + 1)
+        best_idx = np.argmin(stats['pdf'])
+        
+        plt.figure(figsize=figsize)
+        
+        # Subplot 1: PDF
+        plt.subplot(1, 2, 1)
+        colors = ['tab:green' if i == best_idx else 'tab:blue' for i in range(n)]
+        plt.bar(idx, stats['pdf'], color=colors, edgecolor='black', alpha=0.7)
+        plt.axhline(stats['pdf'][best_idx], color='tab:red', ls='--', lw=2, 
+                   label=f'Best = {stats["pdf"][best_idx]:.3f}')
+        plt.xlabel('Realization', fontsize=12)
+        plt.ylabel('PDF', fontsize=12)
+        plt.title(f'PDF Quality Metric (Best: #{best_idx+1})', fontsize=13, fontweight='bold')
+        plt.legend()
+        plt.grid(axis='y', alpha=0.3)
+        
+        # Subplot 2: Spectral Error
+        plt.subplot(1, 2, 2)
+        colors = ['tab:green' if i == best_idx else 'tab:orange' for i in range(n)]
+        plt.bar(idx, stats['err_spectra'], color=colors, edgecolor='black', alpha=0.7)
+        plt.axhline(stats['err_spectra'][best_idx], color='tab:red', ls='--', lw=2, 
+                   label=f'Best = {stats["err_spectra"][best_idx]:.4f}')
+        plt.xlabel('Realization', fontsize=12)
+        plt.ylabel('Spectral Error (RMS)', fontsize=12)
+        plt.title(f'Spectral Error (Best: #{best_idx+1})', fontsize=13, fontweight='bold')
+        plt.legend()
+        plt.grid(axis='y', alpha=0.3)
+        
+        plt.tight_layout()
+        plt.show()
+
+    def plot_temporal_metrics(self, figsize=(15, 5)):
+        """Plot Rise Time, Peak Time, and Rupture Velocity."""
+        import matplotlib.pyplot as plt
+        if self.source_stats is None:
+            print("No source statistics available. Run simulation first.")
+            return
+
+        stats = self.source_stats['source_score']
+        n = stats['n_realizations']
+        idx = np.arange(1, n + 1)
+        best_idx = np.argmin(stats['pdf'])
+
+        plt.figure(figsize=figsize)
+        
+        # Subplot 1: Rise Time
+        plt.subplot(1, 3, 1)
+        plt.plot(idx, stats['ave_tr'], 'o-', color='tab:purple', lw=2, markersize=6)
+        plt.plot(best_idx+1, stats['ave_tr'][best_idx], 's', color='tab:green', 
+                markersize=15, label=f'Best = {stats["ave_tr"][best_idx]:.3f} s', zorder=10)
+        plt.xlabel('Realization', fontsize=12)
+        plt.ylabel('Average Rise Time (s)', fontsize=12)
+        plt.title(f'Rise Time (Best: #{best_idx+1})', fontsize=13, fontweight='bold')
+        plt.legend()
+        plt.grid(alpha=0.3)
+        
+        # Subplot 2: Peak Time
+        plt.subplot(1, 3, 2)
+        plt.plot(idx, stats['ave_tp'], 'o-', color='tab:orange', lw=2, markersize=6)
+        plt.plot(best_idx+1, stats['ave_tp'][best_idx], 's', color='tab:green', 
+                markersize=15, label=f'Best = {stats["ave_tp"][best_idx]:.3f} s', zorder=10)
+        plt.xlabel('Realization', fontsize=12)
+        plt.ylabel('Average Peak Time (s)', fontsize=12)
+        plt.title(f'Peak Time (Best: #{best_idx+1})', fontsize=13, fontweight='bold')
+        plt.legend()
+        plt.grid(alpha=0.3)
+        
+        # Subplot 3: Rupture Velocity
+        plt.subplot(1, 3, 3)
+        plt.plot(idx, stats['ave_vr'], 'o-', color='tab:cyan', lw=2, markersize=6)
+        plt.plot(best_idx+1, stats['ave_vr'][best_idx], 's', color='tab:green', 
+                markersize=15, label=f'Best = {stats["ave_vr"][best_idx]:.3f} km/s', zorder=10)
+        plt.xlabel('Realization', fontsize=12)
+        plt.ylabel('Average Rupture Velocity (km/s)', fontsize=12)
+        plt.title(f'Rupture Velocity (Best: #{best_idx+1})', fontsize=13, fontweight='bold')
+        plt.legend()
+        plt.grid(alpha=0.3)
+        
+        plt.tight_layout()
+        plt.show()
+
+    def plot_spectral_comparison(self, figsize=(14, 6)):
+        """Plot Moment Rate Spectrum and Octave-Averaged Spectrum side by side."""
+        import matplotlib.pyplot as plt
+        if self.source_stats is None:
+            print("No source statistics available. Run simulation first.")
+            return
+        
+        spectrum = self.source_stats['spectrum']
+        octave = self.source_stats['spectrum_octave']
+        plt.figure(figsize=figsize)
+        
+        # Normalize to compare shapes
+        synth_norm = spectrum['moment_rate_synth'] / spectrum['moment_rate_synth'].max()
+        dcf_norm = spectrum['moment_rate_dcf'] / spectrum['moment_rate_dcf'].max()
+        
+        # Subplot 1: Full Spectrum (normalized)
+        plt.subplot(1, 2, 1)
+        plt.loglog(spectrum['freq'], synth_norm, color='tab:blue', lw=2.5, label='Synthetic Model')
+        plt.loglog(spectrum['freq'], dcf_norm, color='tab:red', lw=2.5, ls='--', label='DCF Target')
+        plt.xlabel('Frequency (Hz)', fontsize=12)
+        plt.ylabel('Normalized Moment Rate', fontsize=12)
+        plt.title('Moment Rate Spectrum', fontsize=13, fontweight='bold')
+        plt.legend(fontsize=11)
+        plt.grid(True, which='both', alpha=0.3)
+        
+        # Subplot 2: Octave-Averaged (normalize in log space)
+        plt.subplot(1, 2, 2)
+
+        # Normalize: subtract minimum, then divide by max to get 0-1 range
+        synth_log_norm = octave['logmean_synth'] - octave['logmean_synth'].min()
+        synth_log_norm = synth_log_norm / synth_log_norm.max()
+
+        dcf_log_norm = octave['logmean_dcf'] - octave['logmean_dcf'].min()
+        dcf_log_norm = dcf_log_norm / dcf_log_norm.max()
+
+        plt.semilogx(octave['freq_center'], synth_log_norm, 'o-', color='tab:blue', lw=2.5, markersize=8, label='Synthetic (log-mean)')
+        plt.semilogx(octave['freq_center'], dcf_log_norm, 's--', color='tab:red', lw=2.5, markersize=8, label='DCF Target (log-mean)')
+        plt.xlabel('Frequency (Hz)', fontsize=12)
+        plt.ylabel('Normalized Log Mean Amplitude', fontsize=12)
+        plt.title('Octave-Averaged Spectrum', fontsize=13, fontweight='bold')
+        plt.legend(fontsize=11)
+        plt.grid(alpha=0.3)
+
+    def plot_source_time_function(self, figsize=(10, 6),xlim=None,
+                                save_fig=False, model_name='source', image_type='png'):
+        """Plot Source Time Function (STF)."""
+        import matplotlib.pyplot as plt
+        if self.source_stats is None:
+            print("No source statistics available. Run simulation first.")
+            return
+        
+        stf = self.source_stats['stf_time']
+        plt.figure(figsize=figsize)
+        plt.plot(stf['time'], stf['stf'], color='black', lw=1.5, label='STF')
+        plt.fill_between(stf['time'], 0, stf['stf'], alpha=0.3, color='tab:cyan')
+        max_idx = np.argmax(stf['stf'])
+        plt.plot(stf['time'][max_idx], stf['stf'][max_idx], 'o', color='tab:red', markersize=12, label=f'Peak at t={stf["time"][max_idx]:.2f} s')
+        plt.xlabel('Time (s)', fontsize=12)
+        plt.ylabel('Moment Rate', fontsize=12)
+        plt.title('Source Time Function (STF)', fontsize=14, fontweight='bold')
+        plt.legend(fontsize=11)
+        plt.grid(alpha=0.3)
+        if xlim is not None:
+            plt.xlim(xlim)
+        plt.tight_layout()
+
+        # Save figure if requested
+        if save_fig:
+            plt.savefig(f'{model_name}_source_time_function.{image_type}',
+                        format=image_type, 
+                        dpi=600, 
+                        bbox_inches='tight', 
+                        transparent=True,
+                        facecolor='none')
+
+        plt.show()
+
+    def plot_crust_layers(self, figsize=(6, 4)):
+        """Plot crust model layers"""
+        import matplotlib.pyplot as plt
+        import numpy as np
+        
+        nlayers = self.crust_model.nlayers
+        thicknesses = []
+        labels = []
+        
+        for i in range(nlayers):
+            if self.crust_model.d[i] == 0:  # Half-space
+                thicknesses.append(10)  # Arbitrary for plotting
+                labels.append(f'Layer {i+1}: ∞ (Half-space)')
+            else:
+                thicknesses.append(self.crust_model.d[i])
+                labels.append(f'Layer {i+1}: {self.crust_model.d[i]:.1f} km')
+        
+        fig, ax = plt.subplots(figsize=figsize)
+        
+        colors = plt.cm.Pastel1(np.linspace(0, 1, nlayers))
+        
+        bottom = 0
+        for i in range(nlayers):
+            ax.bar(0, thicknesses[i], bottom=bottom, width=1,
+                   color=colors[i], edgecolor='black', linewidth=1.5,
+                   label=labels[i])
+            bottom += thicknesses[i]
+        
+        ax.set_ylabel('Depth (km)', fontsize=12)
+        ax.set_title('Crust Model Layers', fontsize=14, fontweight='bold')
+        ax.set_xlim(-0.5, 0.5)
+        ax.set_ylim(bottom, 0)  # Inverted
+        ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+        ax.set_xticks([])
+        plt.tight_layout()
+        plt.show()
+
+        
+    def create_animation(self,
+                             field='slip',
+                             figsize=(10, 8),
+                             cmap='cmap_white',
+                             show_contours=True,
+                             contour_field='rupture_time',
+                             show_hypocenter=True,
+                             contour_interval=None,
+                             contour_color='black',
+                             internal_ref=None,
+                             external_coord=None,
+                             rotate=False,
+                             n_frames=50,
+                             fps=10,
+                             dpi=100,
+                             output_dir='animation_frames',
+                             output_video='rupture_animation.mp4',
+                             ffmpeg_path=None):
+            """Create rupture propagation animation.
+
+            Generates one frame per time step, masking subfaults that have not
+            yet ruptured, then assembles frames into a video with ffmpeg.
+
+            Parameters
+            ----------
+            field : str, default 'slip'
+                Field to display. One of 'slip', 'rise_time', 'peak_time'.
+            figsize : tuple, default (10, 8)
+            cmap : str, default 'cmap_white'
+                Colormap. Use 'cmap_white' for white-start YlOrRd.
+            show_contours : bool, default True
+                Overlay rupture time isochrones.
+            contour_field : str, default 'rupture_time'
+            show_hypocenter : bool, default True
+            contour_interval : float, optional
+                Isochrone interval in seconds. Auto if None.
+            contour_color : str, default 'black'
+            internal_ref : list [x, y], optional
+                Reference point in FFSP local coords (km).
+            external_coord : list [x, y], optional
+                Target position in ShakerMaker coords (km).
+            rotate : bool, default False
+            n_frames : int, default 50
+            fps : int, default 10
+            dpi : int, default 100
+            output_dir : str, default 'animation_frames'
+            output_video : str, default 'rupture_animation.mp4'
+            ffmpeg_path : str, optional
+                Full path to ffmpeg binary. Uses system ffmpeg if None.
+            """
+            import os
+            import shutil
+            import subprocess
+            import matplotlib.colors as mcolors
+            import matplotlib.pyplot as plt
+
+            os.makedirs(output_dir, exist_ok=True)
+
+            # --- Colormap ---
+            cmap_base = plt.get_cmap('YlOrRd', 256)
+            colors_arr = cmap_base(np.linspace(0, 1, 256))
+            colors_arr[0] = [1, 1, 1, 1]
+            cmap_white = mcolors.ListedColormap(colors_arr)
+            cmap_plot  = cmap_white if cmap == 'cmap_white' else plt.get_cmap(cmap)
+
+            # --- Geometry ---
+            nx       = int(self.params['nsubx'])
+            ny       = int(self.params['nsuby'])
+            lx       = self.params['fault_length']
+            ly       = self.params['fault_width']
+            cxp      = self.params['x_hypc']
+            cyp      = self.params['y_hypc']
+            strike   = self.params['strike']
+
+            field_labels = {
+                'slip': 'Slip [m]',
+                'rise_time': 'Rise Time [s]',
+                'peak_time': 'Peak Time [s]',
+            }
+
+            # --- Grid data ---
+            rupture_time = np.transpose(self.subfaults['rupture_time'].reshape(nx, ny))
+            field_data   = np.transpose(self.subfaults[field].reshape(nx, ny))
+            contour_data = np.transpose(self.subfaults[contour_field].reshape(nx, ny))
+
+            vmin = field_data.min()
+            vmax = field_data.max()
+
+            # --- Coordinates (same as plot_spacial_distribution) ---
+            x_local = np.linspace(-lx/2, lx/2, nx)
+            y_local = np.linspace(0, ly, ny)
+
+            if rotate:
+                strike_rad = np.radians(strike) + np.radians(90)
+            else:
+                strike_rad = np.radians(strike)
+
+            X_local, Y_local = np.meshgrid(x_local, y_local)
+            X_centered = X_local - (cxp - lx/2)
+            Y_centered = Y_local - cyp
+            X_rot = X_centered * np.sin(strike_rad) + Y_centered * np.cos(strike_rad)
+            Y_rot = X_centered * np.cos(strike_rad) - Y_centered * np.sin(strike_rad)
+
+            if internal_ref is not None and external_coord is not None:
+                ref_x, ref_y = internal_ref
+                if rotate:
+                    ext_y, ext_x = external_coord
+                else:
+                    ext_x, ext_y = external_coord
+                ref_x_rot = ref_x * np.sin(strike_rad) + ref_y * np.cos(strike_rad)
+                ref_y_rot = ref_x * np.cos(strike_rad) - ref_y * np.sin(strike_rad)
+                offset_x  = ext_x - ref_x_rot
+                offset_y  = ext_y - ref_y_rot
+                X = X_rot + offset_x
+                Y = Y_rot + offset_y
+                hypo_x = self.params['xref_hypc'] * np.sin(strike_rad) + self.params['yref_hypc'] * np.cos(strike_rad) + offset_x
+                hypo_y = self.params['xref_hypc'] * np.cos(strike_rad) - self.params['yref_hypc'] * np.sin(strike_rad) + offset_y
+                xlabel = 'UTM Easting, X [km]' if not rotate else 'UTM Northing, Y [km]'
+                ylabel = 'UTM Northing, Y [km]' if not rotate else 'UTM Easting, X [km]'
+            else:
+                X = X_rot + self.params['xref_hypc']
+                Y = Y_rot + self.params['yref_hypc']
+                hypo_x = self.params['xref_hypc']
+                hypo_y = self.params['yref_hypc']
+                xlabel = 'Along Strike [km]' if rotate else 'Along Dip [km]'
+                ylabel = 'Along Dip [km]'    if rotate else 'Along Strike [km]'
+
+            # --- Time steps ---
+            t_max      = rupture_time.max()
+            time_steps = np.linspace(0, t_max, n_frames)
+
+            x_min, x_max = X.min(), X.max()
+            y_min, y_max = Y.min(), Y.max()
+            x_range = x_max - x_min
+            y_range = y_max - y_min
+            pad = 0.05
+
+            print(f"Rendering {n_frames} frames → {output_dir}/")
+
+            for i, t in enumerate(time_steps):
+                mask         = rupture_time <= t
+                field_masked = np.ma.masked_where(~mask, field_data)
+
+                fig, ax = plt.subplots(figsize=figsize)
+                ax.set_facecolor('#E8E8E8')
+                im = ax.pcolormesh(X, Y, field_masked, cmap=cmap_plot,
+                                   shading='auto', vmin=vmin, vmax=vmax)
+
+                from mpl_toolkits.axes_grid1 import make_axes_locatable
+                divider = make_axes_locatable(ax)
+                cax = divider.append_axes("right", size="5%", pad=0.15)
+                cbar = fig.colorbar(im, cax=cax, orientation='vertical')
+                cbar.set_label(field_labels.get(field, field), fontsize=10)
+
+                if show_contours and mask.any():
+                    try:
+                        if contour_interval is not None:
+                            levels = np.arange(0, contour_data[mask].max() + contour_interval,
+                                               contour_interval)
+                            contour_data_masked = np.where(mask, contour_data, np.nan)
+                            cs = ax.contour(X, Y, contour_data_masked, levels=levels,
+                                            colors=contour_color, linewidths=1.5)
+                        else:
+                            contour_data_masked = np.where(mask, contour_data, np.nan)
+                            cs = ax.contour(X, Y, contour_data_masked, 8,
+                                            colors=contour_color, linewidths=1.5)
+                        ax.clabel(cs, fontsize=8, fmt='%.1f', inline=True)
+                    except Exception:
+                        pass
+
+                if show_hypocenter:
+                    ax.scatter(hypo_x, hypo_y, c='white', s=300, marker='*',
+                               edgecolors='black', linewidth=2, zorder=10)
+
+                ax.set_xlabel(xlabel, fontsize=11)
+                ax.set_ylabel(ylabel, fontsize=11)
+                ax.set_title(f't = {t:.2f} s', fontsize=13, fontweight='bold')
+                ax.set_aspect('equal')
+                ax.set_xlim(x_min - pad * x_range, x_max + pad * x_range)
+                ax.set_ylim(y_min - pad * y_range, y_max + pad * y_range)
+
+                for spine in ax.spines.values():
+                    spine.set_visible(True)
+
+                plt.tight_layout()
+                plt.savefig(os.path.join(output_dir, f'frame_{i:03d}.png'), dpi=dpi)
+                plt.close(fig)
+                print(f'Frame {i+1}/{n_frames}', end='\r')
+
+            print(f'\nFrames saved to: {output_dir}')
+
+            # --- Assemble video ---
+            try:
+                ffmpeg_exe = ffmpeg_path or shutil.which('ffmpeg') or 'ffmpeg'
+                subprocess.run([
+                    ffmpeg_exe, '-y',
+                    '-framerate', str(fps),
+                    '-i', os.path.join(output_dir, 'frame_%03d.png'),
+                    '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2',
+                    '-c:v', 'libx264',
+                    '-pix_fmt', 'yuv420p',
+                    '-crf', '18',
+                    output_video
+                ], check=True, capture_output=True)
+                print(f'Video saved: {output_video}')
+            except subprocess.CalledProcessError as e:
+                print(f'ffmpeg error: {e.stderr.decode()[-300:]}')
+            except FileNotFoundError:
+                print(f'ffmpeg not found. Frames are in: {output_dir}')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""ShakerMaker test suite."""

--- a/tests/ffsp/__init__.py
+++ b/tests/ffsp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for FFSP ensemble generation and persistence."""

--- a/tests/ffsp/mpi_all_realization_contract.py
+++ b/tests/ffsp/mpi_all_realization_contract.py
@@ -1,0 +1,32 @@
+"""MPI contract executable for FFSP all-realization products."""
+
+import os
+from pathlib import Path
+import tempfile
+
+import numpy as np
+from mpi4py import MPI
+
+from tests.ffsp.test_all_realization_products import make_source
+
+
+comm = MPI.COMM_WORLD
+shared_dir = Path(tempfile.gettempdir()) / "shakermaker_ffsp_mpi_contract"
+if comm.rank == 0:
+    shared_dir.mkdir(exist_ok=True)
+comm.Barrier()
+os.chdir(shared_dir)
+
+source = make_source(1, 4)
+source.run()
+
+if comm.rank == 0:
+    assert source.all_realizations["stf_time"]["stf"].shape == (131072, 4)
+    assert source.all_realizations["spectrum"]["moment_rate_synth"].shape == (65536, 4)
+    assert source.all_realizations["spectrum_octave"]["logmean_synth"].shape == (16, 4)
+    np.testing.assert_array_equal(source.all_realizations["realization_id"], [1, 2, 3, 4])
+    best_index = int(np.argmin(source.source_stats["source_score"]["pdf"]))
+    assert source.best_realization["realization_id"] == best_index + 1
+    forbidden = {"calsvf.dat", "calsvf_tim.dat", "logsvf.dat"}
+    assert forbidden.isdisjoint(path.name for path in shared_dir.iterdir())
+    print("MPI_FFSP_CONTRACT_PASS")

--- a/tests/ffsp/mpi_idle_rank_contract.py
+++ b/tests/ffsp/mpi_idle_rank_contract.py
@@ -1,0 +1,15 @@
+"""Verify that MPI ranks without FFSP realizations remain safely idle."""
+
+import numpy as np
+from mpi4py import MPI
+
+from tests.ffsp.test_all_realization_products import make_source
+
+
+source = make_source(1, 1)
+source.run()
+
+if MPI.COMM_WORLD.rank == 0:
+    assert source.all_realizations["stf_time"]["stf"].shape == (131072, 1)
+    np.testing.assert_array_equal(source.all_realizations["realization_id"], [1])
+    print("MPI_IDLE_RANK_CONTRACT_PASS")

--- a/tests/ffsp/test_all_realization_products.py
+++ b/tests/ffsp/test_all_realization_products.py
@@ -1,0 +1,181 @@
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+import h5py
+import numpy as np
+
+from shakermaker.crustmodel import CrustModel
+from shakermaker.ffspsource import FFSPSource, _validate_ffsp_kernel_contract
+
+
+KINEMATIC_FIELDS = (
+    "x", "y", "z", "slip", "rupture_time", "rise_time",
+    "peak_time", "strike", "dip", "rake",
+)
+
+
+def make_source(first=1, last=3):
+    crust = CrustModel(4)
+    crust.add_layer(0.200, 1.32, 0.75, 2.40, 1000.0, 1000.0)
+    crust.add_layer(0.800, 2.75, 1.57, 2.50, 1000.0, 1000.0)
+    crust.add_layer(14.500, 5.50, 3.14, 2.50, 1000.0, 1000.0)
+    crust.add_layer(0.000, 7.00, 4.00, 2.67, 1000.0, 1000.0)
+    return FFSPSource(
+        id_sf_type=8, freq_min=0.01, freq_max=24.0,
+        fault_length=30.0, fault_width=16.0,
+        x_hypc=15.0, y_hypc=8.0, depth_hypc=8.0,
+        xref_hypc=0.0, yref_hypc=0.0,
+        magnitude=6.0, fc_main_1=0.09, fc_main_2=3.0,
+        rv_avg=3.0, ratio_rise=0.3,
+        strike=358.0, dip=40.0, rake=113.0,
+        pdip_max=15.0, prake_max=30.0,
+        nsubx=16, nsuby=8, nb_taper_trbl=[5, 5, 5, 5],
+        seeds=[52, 448, 4446], id_ran1=first, id_ran2=last,
+        angle_north_to_x=0.0, is_moment=3,
+        crust_model=crust, output_name="FFSP_TEST", verbose=False,
+    )
+
+
+class TestAllRealizationProducts(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        cls.original_cwd = os.getcwd()
+        os.chdir(cls.temp_dir.name)
+        cls.batch = make_source(1, 3)
+        cls.batch.run()
+        cls.singleton = make_source(2, 2)
+        cls.singleton.run()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.original_cwd)
+        cls.temp_dir.cleanup()
+
+    def test_every_realization_has_complete_products(self):
+        results = self.batch.all_realizations
+        self.assertEqual(results["stf_time"]["stf"].shape, (131072, 3))
+        self.assertEqual(results["spectrum"]["moment_rate_synth"].shape, (65536, 3))
+        self.assertEqual(results["spectrum_octave"]["logmean_synth"].shape, (16, 3))
+        np.testing.assert_array_equal(results["realization_id"], [1, 2, 3])
+
+    def test_stf_normalization_and_spectral_misfit_are_consistent(self):
+        results = self.batch.all_realizations
+        time = results["stf_time"]["time"]
+        stf = results["stf_time"]["stf"]
+        integral = np.trapz(stf, x=time, axis=0)
+        np.testing.assert_allclose(integral, np.ones(3), rtol=1.0e-5, atol=1.0e-5)
+
+        synthetic = results["spectrum_octave"]["logmean_synth"][:12, :]
+        target = results["spectrum_octave"]["logmean_dcf"][:12, None]
+        reconstructed = np.sqrt(np.mean((synthetic - target) ** 2, axis=0))
+        np.testing.assert_allclose(
+            reconstructed, results["metrics"]["err_spectra"],
+            rtol=2.0e-5, atol=2.0e-5,
+        )
+
+    def test_singleton_matches_its_batch_column_bitwise(self):
+        batch = self.batch.all_realizations
+        single = self.singleton.all_realizations
+        for field in KINEMATIC_FIELDS:
+            np.testing.assert_array_equal(batch[field][:, 1], single[field][:, 0])
+        for field in batch["metrics"]:
+            np.testing.assert_array_equal(batch["metrics"][field][1], single["metrics"][field][0])
+        np.testing.assert_array_equal(batch["stf_time"]["time"], single["stf_time"]["time"])
+        np.testing.assert_array_equal(batch["stf_time"]["stf"][:, 1], single["stf_time"]["stf"][:, 0])
+        np.testing.assert_array_equal(batch["spectrum"]["freq"], single["spectrum"]["freq"])
+        np.testing.assert_array_equal(batch["spectrum"]["moment_rate_dcf"], single["spectrum"]["moment_rate_dcf"])
+        np.testing.assert_array_equal(batch["spectrum"]["moment_rate_synth"][:, 1], single["spectrum"]["moment_rate_synth"][:, 0])
+        np.testing.assert_array_equal(batch["spectrum_octave"]["logmean_synth"][:, 1], single["spectrum_octave"]["logmean_synth"][:, 0])
+
+    def test_best_and_active_realizations_carry_their_own_spectra(self):
+        best_index = int(np.argmin(self.batch.source_stats["source_score"]["pdf"]))
+        expected = self.batch.get_realization(best_index)
+        self.assertEqual(self.batch.best_realization["realization_id"], expected["realization_id"])
+        np.testing.assert_array_equal(
+            self.batch.best_realization["spectrum"]["moment_rate_synth"],
+            expected["spectrum"]["moment_rate_synth"],
+        )
+        self.batch.set_active_realization(0)
+        np.testing.assert_array_equal(
+            self.batch.subfaults["stf_time"]["stf"],
+            self.batch.all_realizations["stf_time"]["stf"][:, 0],
+        )
+
+    def test_hdf5_round_trip_preserves_every_product(self):
+        path = Path(self.temp_dir.name) / "round_trip.h5"
+        self.batch.write_hdf5(str(path))
+        loaded = FFSPSource.from_hdf5(str(path))
+        with h5py.File(path, "r") as h5:
+            self.assertEqual(h5.attrs["schema_version"], "2.0")
+            self.assertIn("shakermaker_version", h5.attrs)
+            self.assertIn("spectrum", h5["realizations"])
+            self.assertEqual(h5["realizations/spectrum/moment_rate_synth"].shape, (65536, 3))
+            for dataset_name in (
+                    "realizations/stf_time/stf",
+                    "realizations/spectrum/moment_rate_synth"):
+                dataset = h5[dataset_name]
+                self.assertEqual(dataset.compression, "gzip")
+                self.assertTrue(dataset.shuffle)
+                self.assertEqual(dataset.chunks[1], 1)
+        for index in range(3):
+            original = self.batch.get_realization(index)
+            restored = loaded.get_realization(index)
+            np.testing.assert_array_equal(original["slip"], restored["slip"])
+            np.testing.assert_array_equal(
+                original["spectrum"]["moment_rate_synth"],
+                restored["spectrum"]["moment_rate_synth"],
+            )
+            np.testing.assert_array_equal(original["stf_time"]["stf"], restored["stf_time"]["stf"])
+
+    def test_kernel_does_not_write_shared_spectral_files(self):
+        generated = {path.name for path in Path(self.temp_dir.name).iterdir()}
+        self.assertTrue({"calsvf.dat", "calsvf_tim.dat", "logsvf.dat"}.isdisjoint(generated))
+
+    def test_effective_corner_frequencies_are_traceable(self):
+        self.assertEqual(self.batch.params["fc_main_1_requested"], 0.09)
+        self.assertEqual(self.batch.params["fc_main_2_requested"], 3.0)
+        self.assertAlmostEqual(self.batch.params["fc_main_1"], 0.073282577, places=7)
+        self.assertAlmostEqual(self.batch.params["fc_main_2"], 1.778281, places=6)
+
+    def test_invalid_spectral_band_is_rejected_before_fortran(self):
+        source = make_source(1, 1)
+        source.params.update({
+            "fault_length": 1.0,
+            "fault_width": 1.0,
+            "x_hypc": 0.5,
+            "y_hypc": 0.5,
+            "nsubx": 8,
+            "nsuby": 8,
+            "nb_taper_trbl": [1, 1, 1, 1],
+        })
+        with self.assertRaisesRegex(ValueError, "outside the FFSP octave range"):
+            source.run()
+
+
+class TestFFSPInputValidation(unittest.TestCase):
+    def test_realization_ids_are_one_based(self):
+        source = make_source(0, 1)
+        with self.assertRaisesRegex(ValueError, "id_ran1 must be greater"):
+            _validate_ffsp_kernel_contract(source.params)
+
+    def test_seed_vector_has_exactly_three_entries(self):
+        source = make_source(1, 1)
+        source.params["seeds"] = [52, 448]
+        with self.assertRaisesRegex(ValueError, "exactly three integers"):
+            _validate_ffsp_kernel_contract(source.params)
+
+    def test_derived_seed_overflow_is_rejected_before_fortran(self):
+        source = make_source(71584, 71584)
+        with self.assertRaisesRegex(ValueError, "derived seed3.*exceeds int32"):
+            _validate_ffsp_kernel_contract(source.params)
+
+    def test_last_safe_realization_seed_is_accepted(self):
+        source = make_source(71583, 71583)
+        _validate_ffsp_kernel_contract(source.params)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`FFSPSource` generates an ensemble of rupture realizations but only retained
the complete product set for the single best-scoring one. The spectra of every
other realization were computed and then dropped, so any ensemble statistic
required rerunning the whole generator. This PR keeps the full product set for
all realizations, and makes the seeding deterministic and independent of the
MPI layout so those ensembles are reproducible.

## Dependencies

This PR **must land after** both of the following, and cannot be merged before
them:

| Prerequisite | Why |
|---|---|
| `pr-24-ffsp-kernel` | Provides the vendored FFSP Fortran kernel and the f2py bridge. This PR modifies `dcf_subs_1.f90`, `ffsp_wrapper.f90`, `spfield_n.f90` and `ffsp.pyf`. |
| `pr-25-ffspsource` | Provides `shakermaker/ffspsource.py`, the module this PR extends. |

Those two are siblings — neither contains the other — and this work needs both
at once. So this branch currently carries the `pr-24` kernel commit
cherry-picked on top of `pr-25`, and shows **two** commits. Once `pr-24` and
`pr-25` are merged, a rebase onto upstream `master` drops the duplicate and
this collapses to the single `feat(ffsp)` commit. Reviewers should read only
that commit; the kernel commit is unchanged from `pr-24`.

## What changed

### All realizations keep their products

Previously the per-realization loop computed kinematics, metrics, the source
time function and the spectra, but only the best realization's spectral arrays
survived into the result. Every realization now carries its complete set,
addressed by a global `realization_id`, exposed through
`FFSPSource.all_realizations`. `best_realization` is unchanged in meaning and
still selects on minimum PDF, so existing code that reads it is unaffected.

### Seeding is deterministic and MPI-invariant

Per-realization seeds were derived from rank-local counters, which meant the
same nominal run produced a different ensemble depending on how many ranks it
was spread over. Seeds are now derived from the master seed triple and the
*global* realization id:

```
seed1 + (realization_id - 1) * 10000
seed2 + (realization_id - 1) * 20000
seed3 + (realization_id - 1) * 30000
```

A run therefore yields the same ensemble on 1 rank or on 64. Realization 1
retains the historical FFSP reference stream, so previously published results
reproduce unchanged.

### Seed range validation

The f2py ABI and the FFSP kernel use default 32-bit Fortran `INTEGER`s. Because
the derived offsets grow with realization id, a legal-looking master seed could
silently wrap once multiplied out. Seeds are now validated as Python integers
against the int32 range — both the master triple and each derived value — and
raise `TypeError`/`ValueError` instead of wrapping. Note `seed1` is negated by
the kernel, which the check accounts for.

### Idle ranks

Running with more ranks than realizations is legitimate but previously drove
the surplus ranks into the f2py call with an inverted realization range. Those
ranks now return early with `all_realizations`, `best_realization` and
`active_realization` set to `None`, and the gather asserts consistent spectral
dimensions across ranks rather than silently producing a ragged result.

### Source time function plotted in physical units

The kernel stores the STF normalised to unit area, so the stored array is a
rate in 1/s. `plot_source_time_function` drew it as-is under a "Moment Rate"
label, which reads as N·m/s and is off by a factor of M0. The curve is now
scaled by `M0 = 10 ** (1.5 * Mw + 9.05)` before plotting, the axis is labelled
as the moment rate it has become, and the peak is reported in the legend. The
area under the plotted curve equals M0, which is the check that the scaling is
right.

`FFSP_MAGNITUDE_CONSTANT` holds the 9.05 the kernel uses, so the conversion is
not re-derived at each call site. Hanks and Kanamori (1979) use 9.1 in SI; the
resulting 0.033 offset in magnitude is a convention difference, not an error,
and the constant is named so this stays visible.

## How to verify

Serial suite:

```
python -m unittest tests.ffsp.test_all_realization_products -v
```

It covers that all realizations are returned with `realization_id == [1,2,3]`,
that each STF integrates to unity within 1e-5, that a batch run of N
realizations reproduces element-for-element the single runs of each — slip,
metrics, `stf_time`, `spectrum`, `spectrum_octave` — and that a save/load
round-trip preserves slip and STF. A separate `TestFFSPInputValidation` covers
the seed-range rejection.

MPI contracts, run as standalone scripts:

```
mpirun -n 3 python -m tests.ffsp.mpi_all_realization_contract
mpirun -n 4 python -m tests.ffsp.mpi_idle_rank_contract
```

Each prints a `..._PASS` line on rank 0. The idle-rank contract deliberately
requests 1 realization on 4 ranks to exercise the early-return path.

## Out of scope

Two files touched by this work are deliberately excluded, because they belong
to other PR lineages and would make this diff cross-cutting:

- `examples/.../ffsp_all_realization_products.ipynb` — belongs with the
  examples reorganization (`pr-30-examples`).
- `docs/web/.../SCRIPTS/03_shakermaker_build.ps1` — belongs with
  `pr-19-win-scripts`.

Both are available and can be submitted separately on request.