### PR TITLE
36fix(crust): label layer thickness with three-decimal precision

### DIFF
--- a/shakermaker/crustmodel.py
+++ b/shakermaker/crustmodel.py
@@ -347,7 +347,7 @@ class CrustModel:
 
         plt.subplot(1, 3, 1)
         for i in range(self.nlayers):
-            label = f'Layer {i+1}: inf' if self._d[i] == 0 else f'Layer {i+1}: {self._d[i]:.1f} km'
+            label = f'Layer {i+1}: inf' if self._d[i] == 0 else f'Layer {i+1}: {self._d[i]:.3f} km'
             plt.axhspan(z_top[i], z_top[i+1], facecolor=colors[i], alpha=0.4, label=label)
         plt.plot(vp_step, z_step, color='C0', linewidth=2)
         plt.xlabel('Vp (km/s)', fontsize=12)


### PR DESCRIPTION
## Summary

One-line fix to the layer legend in `CrustModel.plot()`. Layer thickness is
formatted with `.1f`, so any two layers whose thicknesses differ by less than
0.1 km print an identical label and become indistinguishable in the legend.
This changes the format to `.3f`.

## Dependencies

None outstanding. This builds on `pr-04-crust`, which introduced
`plot()`/`plot_profile()` and is already merged upstream. The branch is cut
from current `master`, so it applies as-is.

## What changed

`shakermaker/crustmodel.py`, one line in the legend construction of `plot()`:

```diff
-label = f'Layer {i+1}: inf' if self._d[i] == 0 else f'Layer {i+1}: {self._d[i]:.1f} km'
+label = f'Layer {i+1}: inf' if self._d[i] == 0 else f'Layer {i+1}: {self._d[i]:.3f} km'
```

The `inf` branch for the half-space (thickness stored as `0.0`) is untouched.

## Why it matters

Thin near-surface layers are common in validation profiles and in CRUST1.0
extractions, where sub-100 m layers appear routinely. With one decimal, a
profile containing 0.02 km and 0.04 km layers renders two legend entries both
reading `0.0 km`, which makes the plot unusable for exactly the models where
the layering detail matters most. Three decimals resolve to the metre.

## How to verify

Build any model with sub-100 m layers and plot it:

```python
from shakermaker.crustmodel import CrustModel

crust = CrustModel(3)
crust.add_layer(0.024, 1.5, 0.6, 1.8, 200.0, 100.0)
crust.add_layer(0.041, 1.9, 0.9, 1.9, 300.0, 150.0)
crust.add_layer(0.0,   3.2, 1.8, 2.2, 500.0, 250.0)
crust.plot()
```

Before: the first two legend entries both read `0.0 km`. After: they read
`0.024 km` and `0.041 km`.

## Scope

Presentation only. No change to any stored value, computation, or public API;
`self._d` is read but never modified.